### PR TITLE
Allow multiple nameservers

### DIFF
--- a/lib/logstash/filters/dns.rb
+++ b/lib/logstash/filters/dns.rb
@@ -42,8 +42,8 @@ class LogStash::Filters::DNS < LogStash::Filters::Base
   # specified under `reverse` and `resolve`.
   config :action, :validate => [ "append", "replace" ], :default => "append"
 
-  # Use custom nameserver(s).
-  config :nameservers, :validate => :array
+  # Use custom nameserver(s). For example: `["8.8.8.8", "8.8.4.4"]`
+  config :nameserver, :validate => :array
 
   # `resolv` calls will be wrapped in a timeout instance
   config :timeout, :validate => :number, :default => 2
@@ -52,10 +52,10 @@ class LogStash::Filters::DNS < LogStash::Filters::Base
   def register
     require "resolv"
     require "timeout"
-    if @nameservers.nil?
+    if @nameserver.nil?
       @resolv = Resolv.new
     else
-      @resolv = Resolv.new(resolvers=[::Resolv::Hosts.new, ::Resolv::DNS.new(:nameserver => @nameservers, :search => [], :ndots => 1)])
+      @resolv = Resolv.new(resolvers=[::Resolv::Hosts.new, ::Resolv::DNS.new(:nameserver => @nameserver, :search => [], :ndots => 1)])
     end
 
     @ip_validator = Resolv::AddressRegex

--- a/lib/logstash/filters/dns.rb
+++ b/lib/logstash/filters/dns.rb
@@ -42,8 +42,8 @@ class LogStash::Filters::DNS < LogStash::Filters::Base
   # specified under `reverse` and `resolve`.
   config :action, :validate => [ "append", "replace" ], :default => "append"
 
-  # Use custom nameserver.
-  config :nameserver, :validate => :string
+  # Use custom nameserver(s).
+  config :nameservers, :validate => :array
 
   # `resolv` calls will be wrapped in a timeout instance
   config :timeout, :validate => :number, :default => 2
@@ -52,10 +52,10 @@ class LogStash::Filters::DNS < LogStash::Filters::Base
   def register
     require "resolv"
     require "timeout"
-    if @nameserver.nil?
+    if @nameservers.nil?
       @resolv = Resolv.new
     else
-      @resolv = Resolv.new(resolvers=[::Resolv::Hosts.new, ::Resolv::DNS.new(:nameserver => [@nameserver], :search => [], :ndots => 1)])
+      @resolv = Resolv.new(resolvers=[::Resolv::Hosts.new, ::Resolv::DNS.new(:nameserver => @nameservers, :search => [], :ndots => 1)])
     end
 
     @ip_validator = Resolv::AddressRegex

--- a/spec/filters/dns_spec.rb
+++ b/spec/filters/dns_spec.rb
@@ -206,4 +206,36 @@ describe LogStash::Filters::DNS do
       insist { subject["foo"] } == "does.not.exist"
     end
   end
+
+  describe "dns resolve lookup, single custom nameserver" do
+    config <<-CONFIG
+      filter {
+        dns {
+          resolve => ["host"]
+          action => "replace"
+          nameserver => "8.8.8.8"
+        }
+      }
+    CONFIG
+
+    sample("host" => "carrera.databits.net") do
+      insist { subject["host"] } == "199.192.228.250"
+    end
+  end
+
+  describe "dns resolve lookup, multiple nameserver fallback" do
+    config <<-CONFIG
+      filter {
+        dns {
+          resolve => ["host"]
+          action => "replace"
+          nameserver => ["127.0.0.99", "8.8.8.8"]
+        }
+      }
+    CONFIG
+
+    sample("host" => "carrera.databits.net") do
+      insist { subject["host"] } == "199.192.228.250"
+    end
+  end
 end


### PR DESCRIPTION
Fixes https://github.com/logstash-plugins/logstash-filter-dns/issues/9.
I changed the config name from `nameserver` to `nameservers` to better represent an array. It's up to you if the break in backwards compatibility is acceptable.