### PR TITLE
Resolv's methods return objects, not strings.

### DIFF
--- a/lib/logstash/filters/dns.rb
+++ b/lib/logstash/filters/dns.rb
@@ -112,7 +112,7 @@ class LogStash::Filters::DNS < LogStash::Filters::Base
 
       begin
         # in JRuby 1.7.11 outputs as US-ASCII
-        address = @resolv.getaddress(raw).force_encoding(Encoding::UTF_8)
+        address = @resolv.getaddress(raw).to_s.force_encoding(Encoding::UTF_8)
       rescue Resolv::ResolvError
         @logger.debug("DNS: couldn't resolve the hostname.",
                       :field => field, :value => raw)
@@ -171,7 +171,7 @@ class LogStash::Filters::DNS < LogStash::Filters::Base
       end
       begin
         # in JRuby 1.7.11 outputs as US-ASCII
-        hostname = @resolv.getname(raw).force_encoding(Encoding::UTF_8)
+        hostname = @resolv.getname(raw).to_s.force_encoding(Encoding::UTF_8)
       rescue Resolv::ResolvError
         @logger.debug("DNS: couldn't resolve the address.",
                       :field => field, :value => raw)

--- a/spec/filters/dns_spec.rb
+++ b/spec/filters/dns_spec.rb
@@ -5,13 +5,13 @@ require "resolv"
 
 describe LogStash::Filters::DNS do
   before(:each) do
-    allow_any_instance_of(Resolv).to receive(:getaddress).with("carrera.databits.net").and_return("199.192.228.250")
+    allow_any_instance_of(Resolv).to receive(:getaddress).with("carrera.databits.net").and_return(Resolv::IPv4.create "199.192.228.250")
     allow_any_instance_of(Resolv).to receive(:getaddress).with("does.not.exist").and_raise(Resolv::ResolvError)
     allow_any_instance_of(Resolv).to receive(:getaddress).with("nonexistanthostname###.net").and_raise(Resolv::ResolvError)
-    allow_any_instance_of(Resolv).to receive(:getname).with("199.192.228.250").and_return("carrera.databits.net")
-    allow_any_instance_of(Resolv).to receive(:getname).with("127.0.0.1").and_return("localhost")
+    allow_any_instance_of(Resolv).to receive(:getname).with("199.192.228.250").and_return(Resolv::DNS::Name.create "carrera.databits.net")
+    allow_any_instance_of(Resolv).to receive(:getname).with("127.0.0.1").and_return(Resolv::DNS::Name.create "localhost")
     allow_any_instance_of(Resolv).to receive(:getname).with("128.0.0.1").and_raise(Resolv::ResolvError)
-    allow_any_instance_of(Resolv).to receive(:getname).with("199.192.228.250").and_return("carrera.databits.net")
+    allow_any_instance_of(Resolv).to receive(:getname).with("199.192.228.250").and_return(Resolv::DNS::Name.create "carrera.databits.net")
   end
 
   describe "dns reverse lookup, replace (on a field)" do


### PR DESCRIPTION
Resolv's `getaddress()` and `getname()` both return objects now that
have to be converted to strings before using them.

I suspect that Resolv changed at some-point in the past.  While the
new changes to the specs won't work with older rubies, the code
should work with older versions of jruby.

Probably some integration tests should be added for this.

Fixes #11