### PR TITLE
remove explicit return block that terminates rspec run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
-# 2.1.2
+## 2.1.3
+  - Fix spec early termination by removing an explicit return from a block
+
+## 2.1.2
   - Depend on logstash-core-plugin-api instead of logstash-core, removing the need to mass update plugins on major releases of logstash
-# 2.1.1
+
+## 2.1.1
   - New dependency requirements for logstash-core for the 5.0 release
+
 ## 2.1.0
  - Add caches for failed and successful lookups
  - Lower default timeout value

--- a/logstash-filter-dns.gemspec
+++ b/logstash-filter-dns.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-dns'
-  s.version         = '2.1.2'
+  s.version         = '2.1.3'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This filter will resolve any IP addresses from a field of your choosing."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/dns_spec.rb
+++ b/spec/filters/dns_spec.rb
@@ -343,11 +343,11 @@ describe LogStash::Filters::DNS do
       before(:each) do
         allow(subject).to receive(:getaddress) do
           @try ||= 0
-          if @try < 3
+          if @try < 2
             @try = @try + 1
             raise Timeout::Error
           else
-            return "127.0.0.1"
+            "127.0.0.1"
           end
         end
       end


### PR DESCRIPTION
because of an explicit return from a block the spec suite was terminating earlier and not running all the tests

before this PR (10 tests are executed):

```
% bundle exec rspec -s 59466
Run options: exclude {:redis=>true, :socket=>true, :performance=>true, :couchdb=>true, :elasticsearch=>true, :elasticsearch_secure=>true, :export_cypher=>true, :integration=>true, :windows=>true}
.........

Finished in 0.899 seconds (files took 4.16 seconds to load)
10 examples, 0 failures

Randomized with seed 59466
```

after this pr (21 tests are executed):

```
% bundle exec rspec -s 59466
Run options: exclude {:redis=>true, :socket=>true, :performance=>true, :couchdb=>true, :elasticsearch=>true, :elasticsearch_secure=>true, :export_cypher=>true, :integration=>true, :windows=>true}
.....................

Finished in 1.58 seconds (files took 4.03 seconds to load)
21 examples, 0 failures

Randomized with seed 59466
```