### PR TITLE
Changed cache behavior such that timeouts are cached along with failures

### DIFF
--- a/lib/logstash/filters/dns.rb
+++ b/lib/logstash/filters/dns.rb
@@ -144,6 +144,7 @@ class LogStash::Filters::DNS < LogStash::Filters::Base
                       :field => field, :value => raw)
         return
       rescue Resolv::ResolvTimeout, Timeout::Error
+        @failed_cache[raw] = true if @failed_cache
         @logger.error("DNS: timeout on resolving the hostname.",
                       :field => field, :value => raw)
         return
@@ -204,6 +205,7 @@ class LogStash::Filters::DNS < LogStash::Filters::Base
                       :field => field, :value => raw)
         return
       rescue Resolv::ResolvTimeout, Timeout::Error
+        @failed_cache[raw] = true if @failed_cache
         @logger.error("DNS: timeout on resolving address.",
                       :field => field, :value => raw)
         return


### PR DESCRIPTION
I've had issues with the DNS plugin and resolving large amounts of domain names.  I've found that timeouts are almost always a sign that the query is never going to succeeded from my configured DNS server, rather than an indication of a network issue.

Therefore, I modified my local copy of this plugin to treat timeouts as failures so that they can be cached.
