### PR TITLE
Resolve race condition when threads might get killed when waiting for read /etc/hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.4 
+  - Fix race condition described at https://github.com/logstash-plugins/logstash-filter-dns/issues/26 by adding extra locking around the dns resolve operations that trigger the problem, this makes the concurrency issue when reading the host file go.
+
 ## 3.0.3
   - Relax constraint on logstash-core-plugin-api to >= 1.60 <= 2.99
 

--- a/lib/logstash/filters/dns.rb
+++ b/lib/logstash/filters/dns.rb
@@ -86,7 +86,6 @@ class LogStash::Filters::DNS < LogStash::Filters::Base
     end
 
     @ip_validator = Resolv::AddressRegex
-    @mutex        = Mutex.new
   end # def register
 
   public
@@ -265,20 +264,13 @@ class LogStash::Filters::DNS < LogStash::Filters::Base
 
   private
   def getname(address)
-    name = nil
-    @mutex.synchronize {
-      name = @resolv.getname(address).force_encoding(Encoding::UTF_8)
-    }
+    name = @resolv.getname(address).force_encoding(Encoding::UTF_8)
     IDN.toUnicode(name)
   end
 
   private
   def getaddress(name)
     idn = IDN.toASCII(name)
-    addr = nil
-    @mutex.synchronize {
-      addr = @resolv.getaddress(idn).force_encoding(Encoding::UTF_8)
-    }
-    addr
+    @resolv.getaddress(idn).force_encoding(Encoding::UTF_8)
   end
 end # class LogStash::Filters::DNS

--- a/lib/logstash/filters/dns/resolv_patch.rb
+++ b/lib/logstash/filters/dns/resolv_patch.rb
@@ -1,0 +1,36 @@
+# encoding: utf-8
+require "resolv"
+
+class Resolv
+  class DNS
+
+    def timeouts=(timeouts)
+      @config.timeouts = timeouts
+    end
+
+    class Config
+
+      def timeouts=(values)
+        if values
+          values = Array(values)
+          values.each do |t|
+            Numeric === t or raise ArgumentError, "#{t.inspect} is not numeric"
+            t > 0.0 or raise ArgumentError, "timeout=#{t} must be postive"
+          end
+          @timeouts = values
+        else
+          @timeouts = nil
+        end
+      end
+
+      def generate_timeouts
+        return @timeouts if !@timeouts.nil?
+        ts = [InitialTimeout]
+        ts << ts[-1] * 2 / @nameserver_port.length
+        ts << ts[-1] * 2
+        ts << ts[-1] * 2
+        return ts
+      end
+    end
+  end
+end

--- a/logstash-filter-dns.gemspec
+++ b/logstash-filter-dns.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-dns'
-  s.version         = '3.0.3'
+  s.version         = '3.0.4'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This filter will resolve any IP addresses from a field of your choosing."
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/dns_spec.rb
+++ b/spec/filters/dns_spec.rb
@@ -331,7 +331,7 @@ describe LogStash::Filters::DNS do
 
       context "when failing permanently" do
         before(:each) do
-          allow(subject).to receive(:getaddress).and_raise(Timeout::Error)
+          allow(subject).to receive(:getaddress).and_raise(Resolv::ResolvTimeout)
         end
 
         it "should fail a resolve after max_retries" do
@@ -346,7 +346,7 @@ describe LogStash::Filters::DNS do
             @try ||= 0
             if @try < 2
               @try = @try + 1
-              raise Timeout::Error
+              raise  Resolv::ResolvTimeout
             else
               "127.0.0.1"
             end


### PR DESCRIPTION
Hi,
  before moving forward a good understanding of the issue #26 would be necessary, please read and don't hesitate to ask any doubt you might have, happy to provide all clarification as need. 

~~The solution proposed here goes on the direction of being sure that only 1 thread is entering the jruby resolv land, this will certainly make resolv operation a bit slower, but until the upstream issue gets fixed might be the only way to get this issue fix for Logstash.~~

~~Discarded solution for this problem.~~

~~You might think to also initialize the resolver manually before the plugin starts running time, however I discarded this option. For me it was more safe to keep internal jruby logic as it's without touching internals, so we don't cause more issues, probably all unkown.~~

This PR got updated with current status of the discussions inside issue #26, short version it add's a patch to let the user change the timeout for the `Resolv::DNS` internal Ruby class. This brings to 1.9 mode, the one Logstash is running, the desired behaviour currently only available for the 2.x ruby series. This solution also include the removal of current usage of the timeout module, the one causing threads to be killed.

Fixes #26 
Related https://github.com/jruby/jruby/issues/4048
