### PR TITLE
Log a warning on missing resolve/reverse fields instead of crashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.4
+  - Log a warning on missing resolve/reverse fields rather than crashing
+
 ## 3.0.3
   - Relax constraint on logstash-core-plugin-api to >= 1.60 <= 2.99
 

--- a/lib/logstash/filters/dns.rb
+++ b/lib/logstash/filters/dns.rb
@@ -122,6 +122,12 @@ class LogStash::Filters::DNS < LogStash::Filters::Base
     @resolve.each do |field|
       is_array = false
       raw = event.get(field)
+
+      if raw.nil?
+        @logger.warn("DNS filter could not resolve missing field", :field => field)
+        next
+      end
+
       if raw.is_a?(Array)
         is_array = true
         if raw.length > 1
@@ -176,6 +182,12 @@ class LogStash::Filters::DNS < LogStash::Filters::Base
   def reverse(event)
     @reverse.each do |field|
       raw = event.get(field)
+
+      if raw.nil?
+        @logger.warn("DNS filter could not perform reverse lookup on missing field", :field => field)
+        next
+      end
+
       is_array = false
       if raw.is_a?(Array)
           is_array = true

--- a/logstash-filter-dns.gemspec
+++ b/logstash-filter-dns.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-dns'
-  s.version         = '3.0.4'
+  s.version         = '3.0.5'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This filter will resolve any IP addresses from a field of your choosing."
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/dns_spec.rb
+++ b/spec/filters/dns_spec.rb
@@ -30,6 +30,27 @@ describe LogStash::Filters::DNS do
       end
     end
 
+    describe "dns reverse lookup, missing field" do
+      let(:plugin) { ::LogStash::Filters::DNS.new("reverse" => "foo") }
+      let(:event) { ::LogStash::Event.new }
+
+      before do
+        plugin.register
+        allow(plugin.logger).to receive(:warn).with(any_args)
+      end
+
+      it "should not throw an error when filtering" do
+        expect do
+          plugin.filter(event)
+        end.not_to raise_error
+      end
+
+      it "should log a warning" do
+        plugin.filter(event)
+        expect(plugin.logger).to have_received(:warn).with("DNS filter could not perform reverse lookup on missing field", :field => "foo")
+      end
+    end
+
     describe "dns reverse lookup, append" do
       config <<-CONFIG
         filter {
@@ -74,6 +95,27 @@ describe LogStash::Filters::DNS do
       sample("host" => "carrera.databits.net") do
         insist { subject.get("host") } == "199.192.228.250"
         insist { subject.get("tags") } == ["success"]
+      end
+    end
+
+    describe "dns resolve lookup, missing field" do
+      let(:plugin) { ::LogStash::Filters::DNS.new("resolve" => "foo") }
+      let(:event) { ::LogStash::Event.new }
+
+      before do
+        plugin.register
+        allow(plugin.logger).to receive(:warn).with(any_args)
+      end
+
+      it "should not throw an error when filtering" do
+        expect do
+          plugin.filter(event)
+        end.not_to raise_error
+      end
+
+      it "should log a warning" do
+        plugin.filter(event)
+        expect(plugin.logger).to have_received(:warn).with("DNS filter could not resolve missing field", :field => "foo")
       end
     end
 


### PR DESCRIPTION
This fixes a bug reported here: https://discuss.elastic.co/t/logstash-crashes-in-dns-filter/94810
If a specified field is empty or missing this filter will currently crash with an NPE. This patch checks that all fields are not nil before attempting to resolve them, logging a warning where appropriate.

A future patch should probably add a tag_on_failure feature
