### PR TITLE
Added message output to ResolvError debug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.9
+  - PR 36 - Logging improvement to include DNS resolution failure reason
+
 ## 3.0.8
   - Fix bug where forward lookups would not cache timeout errors
 

--- a/lib/logstash/filters/dns.rb
+++ b/lib/logstash/filters/dns.rb
@@ -146,10 +146,10 @@ class LogStash::Filters::DNS < LogStash::Filters::Base
         else
           address = retriable_getaddress(raw)
         end
-      rescue Resolv::ResolvError
+      rescue Resolv::ResolvError => e
         @failed_cache[raw] = true if @failed_cache
         @logger.debug("DNS: couldn't resolve the hostname.",
-                      :field => field, :value => raw)
+                      :field => field, :value => raw, :message => e.message)
         return
       rescue Resolv::ResolvTimeout, Timeout::Error
         @failed_cache[raw] = true if @failed_cache
@@ -213,10 +213,10 @@ class LogStash::Filters::DNS < LogStash::Filters::Base
         else
           hostname = retriable_getname(raw)
         end
-      rescue Resolv::ResolvError
+      rescue Resolv::ResolvError => e
         @failed_cache[raw] = true if @failed_cache
         @logger.debug("DNS: couldn't resolve the address.",
-                      :field => field, :value => raw)
+                      :field => field, :value => raw, :message => e.message)
         return
       rescue Resolv::ResolvTimeout, Timeout::Error
         @failed_cache[raw] = true if @failed_cache

--- a/logstash-filter-dns.gemspec
+++ b/logstash-filter-dns.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-dns'
-  s.version         = '3.0.8'
+  s.version         = '3.0.9'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Performs a standard or reverse DNS lookup"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
`ResolvError` is just [a straight subclass](https://github.com/sj26/ruby-1.9.3-p0/blob/master/lib/resolv.rb#L157) of `StandardError` that will get useful messages (e.g. [here](https://github.com/sj26/ruby-1.9.3-p0/blob/master/lib/resolv.rb#L93))
