### PR TITLE
Avoid crashed of the plugin by illegal characters in the input value

### DIFF
--- a/lib/logstash/filters/dns.rb
+++ b/lib/logstash/filters/dns.rb
@@ -282,7 +282,7 @@ class LogStash::Filters::DNS < LogStash::Filters::Base
 
   private
   def getaddress(name)
-        idn = IDN.toASCII(name)
+    idn = IDN.toASCII(name)
   rescue java.lang.IllegalArgumentException => e
     @logger.error("DNS: Illegal character in the input value.",
                    :field => field, :value => raw)

--- a/lib/logstash/filters/dns.rb
+++ b/lib/logstash/filters/dns.rb
@@ -282,7 +282,11 @@ class LogStash::Filters::DNS < LogStash::Filters::Base
 
   private
   def getaddress(name)
-    idn = IDN.toASCII(name)
+        idn = IDN.toASCII(name)
+  rescue java.lang.IllegalArgumentException => e
+    @logger.error("DNS: Illegal character in the input value.",
+                   :field => field, :value => raw)
+    return
     @resolv.getaddress(idn).force_encoding(Encoding::UTF_8)
   end
 end # class LogStash::Filters::DNS


### PR DESCRIPTION
I have created a pull request to avoid crashed of this plugin by illegal characters in the input value.

This issue is also mentioned at :
https://github.com/logstash-plugins/logstash-filter-dns/issues/31

Please double-check if it makes sense to place the exception at the end.

Thanks
Stefan