### PR TITLE
allow concurrent queries when cache enabled

### DIFF
--- a/lib/logstash/filters/dns.rb
+++ b/lib/logstash/filters/dns.rb
@@ -144,8 +144,7 @@ class LogStash::Filters::DNS < LogStash::Filters::Base
         if @hit_cache
           address = @hit_cache[raw]
           if address.nil?
-            address = retriable_getaddress(raw)
-            unless address.nil?
+            if address = retriable_getaddress(raw)
               @hit_cache[raw] = address
             end
           end
@@ -217,8 +216,7 @@ class LogStash::Filters::DNS < LogStash::Filters::Base
         if @hit_cache
           hostname = @hit_cache[raw]
           if hostname.nil?
-            hostname = retriable_getname(raw)
-            unless hostname.nil?
+            if hostname = retriable_getname(raw)
               @hit_cache[raw] = hostname
             end
           end

--- a/lib/logstash/filters/dns.rb
+++ b/lib/logstash/filters/dns.rb
@@ -142,7 +142,13 @@ class LogStash::Filters::DNS < LogStash::Filters::Base
       begin
         return if @failed_cache && @failed_cache[raw] # recently failed resolv, skip
         if @hit_cache
-          address = @hit_cache.getset(raw) { retriable_getaddress(raw) }
+          address = @hit_cache[raw]
+          if address.nil?
+            address = retriable_getaddress(raw)
+            unless address.nil?
+              @hit_cache[raw] = address
+            end
+          end
         else
           address = retriable_getaddress(raw)
         end
@@ -209,7 +215,13 @@ class LogStash::Filters::DNS < LogStash::Filters::Base
       begin
         return if @failed_cache && @failed_cache.key?(raw) # recently failed resolv, skip
         if @hit_cache
-          hostname = @hit_cache.getset(raw) { retriable_getname(raw) }
+          hostname = @hit_cache[raw]
+          if hostname.nil?
+            hostname = retriable_getname(raw)
+            unless hostname.nil?
+              @hit_cache[raw] = hostname
+            end
+          end
         else
           hostname = retriable_getname(raw)
         end


### PR DESCRIPTION
When caching features are enabled, queries are forwarded to the name server syncronously. The result being that slow returning queries slow the processing of all data.

To evaluate the effect of these changes I extracted 5 million IP addresses from the logs of a large firewall, which ensures that the mix of IPs is similar to what would be seen in the real-world. I then repeated these 5 million IPs to have a file with 10 million addresses. The data was then processed locally on my Macbook Pro, with a DNS server on the local LAN which forwards the necessary queries to 1.1.1.1 and 8.8.8.8.

To establish a baseline these 10M IPs were passed to Elasticsearch through the following filters:
```
filter {
  mutate {
    rename => { "message" => "ipaddr" }
    remove_field => [ "path", "host", "@version" ]
  }
  mutate {
    add_field => { "hostname" => "%{ipaddr}" }
  }
}
```
The result was approx 41000-42000 eps.

<img width="392" alt="screen shot 2018-05-05 at 17 48 24" src="https://user-images.githubusercontent.com/10326954/39666771-755c69c2-50a9-11e8-93e9-f27d37da4c6c.png">

Next a `dns` filter was added **without** caching.
```
filter {
  mutate {
    rename => { "message" => "ipaddr" }
    remove_field => [ "path", "host", "@version" ]
  }
  mutate {
    add_field => { "hostname" => "%{ipaddr}" }
  }
  dns {
    reverse => [ "hostname" ]
    action => "replace"
    nameserver => "192.168.1.1"
  }
}
```
Knowing this would be slower I switched to using only the first 100K entries. The results plummet to ~450 eps.

<img width="254" alt="screen shot 2018-05-05 at 17 52 24" src="https://user-images.githubusercontent.com/10326954/39666853-c49b5eca-50aa-11e8-8ce4-a1995d31be09.png">

Next caching is enabled...
```
  dns {
    reverse => [ "hostname" ]
    action => "replace"
    nameserver => "192.168.1.1"
    hit_cache_size => 8192
    hit_cache_ttl => 900
    failed_cache_size => 2048
    failed_cache_ttl => 900
  }
```
The results are much more inconsistent as queries that can not be answered by downstream servers block other queries until a timeout occurs.

<img width="343" alt="screen shot 2018-05-05 at 18 17 59" src="https://user-images.githubusercontent.com/10326954/39667002-49d65f2a-50ad-11e8-8eba-05d41cffbd9a.png">

> NOTE: You will notice that things improve in the later part of the test. This is thanks to #41 which was added in the last release. The latter part of the data has a lot of IPs that would timeout, and you can see here that #41 now caching these has a positive impact.

I then applied this PR and the improvement with the first 100K was obvious. The peak was over 2000 eps.

<img width="231" alt="screen shot 2018-05-05 at 18 56 34" src="https://user-images.githubusercontent.com/10326954/39667141-e2ce938a-50af-11e8-8e38-6fe7b6ba9fbf.png">

I then switched back to the 10M record file. Remember, this is the same 5M records twice.

<img width="675" alt="screen shot 2018-05-05 at 19 28 54" src="https://user-images.githubusercontent.com/10326954/39667220-378df5ae-50b1-11e8-8d7a-a9002efb5a35.png">

Here you can see how the performance continues to improve as the cache fills. However I was a bit disappointed in the results. From the two spikes, one as high as 40,000 eps, you can see the performance promises to be very good if the query result is already cached. While 10-15,000 eps is a huge improvement over the 450-500 eps we were seeing, when the 5M records are repeated in the second half of the file, I would have expected better results.

I suspected the results were being ejected from the cache as it filled, so I increased the size of the cache and retested:
```
  dns {
    reverse => [ "hostname" ]
    action => "replace"
    nameserver => "192.168.1.1"
    hit_cache_size => 131072
    hit_cache_ttl => 900
    failed_cache_size => 131072
    failed_cache_ttl => 900
  }
```
With plenty of cache for all results in this real-world data sample, the advantage of the results being in the cache is clear.

<img width="673" alt="screen shot 2018-05-05 at 19 46 06" src="https://user-images.githubusercontent.com/10326954/39667288-068ee9fc-50b3-11e8-89cf-a7ad3274ec99.png">

The original data without any DNS filter was 41,000 eps. With the DNS filter and a warmed up cache, 40,000 eps was possible. This indicates that the additional overhead is minimal.

With this PR I finally feel comfortable that I can use the DNS filter in production deployments without sacrificing ingest performance. This is a huge win for producing user-friendly data!

