### PR TITLE
Sensible log levels

### DIFF
--- a/lib/logstash/filters/dns.rb
+++ b/lib/logstash/filters/dns.rb
@@ -159,7 +159,7 @@ class LogStash::Filters::DNS < LogStash::Filters::Base
         return
       rescue Resolv::ResolvTimeout, Timeout::Error
         @failed_cache[raw] = true if @failed_cache
-        @logger.error("DNS: timeout on resolving the hostname.",
+        @logger.warn("DNS: timeout on resolving the hostname.",
                       :field => field, :value => raw)
         return
       rescue SocketError => e
@@ -232,7 +232,7 @@ class LogStash::Filters::DNS < LogStash::Filters::Base
         return
       rescue Resolv::ResolvTimeout, Timeout::Error
         @failed_cache[raw] = true if @failed_cache
-        @logger.error("DNS: timeout on resolving address.",
+        @logger.warn("DNS: timeout on resolving address.",
                       :field => field, :value => raw)
         return
       rescue SocketError => e


### PR DESCRIPTION
This PR changes the log level of DNS query timeouts from error to warn.

Timeouts mostly occur when the upstream DNS servers are not configured to provide a response. This is often intentional, especially with public IP addresses of questionable reputation.

Logging these as an error could unnecessarily concern users.
