### PR TITLE
bump to 3.0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.10
+  - Log timeouts as warn instead of error #43
+  - Allow concurrent queries when cache enabled #42
+
 ## 3.0.9
   - Logging improvement to include DNS resolution failure reason #36
 

--- a/logstash-filter-dns.gemspec
+++ b/logstash-filter-dns.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-dns'
-  s.version         = '3.0.9'
+  s.version         = '3.0.10'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Performs a standard or reverse DNS lookup"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
changelog constructed from:

```
 % git lg v3.0.9..
* 0f66369 - (origin/master, origin/HEAD, master) log timeouts as warn instead of error (#43) (2 hours ago) <Rob Cowart>
* e405c0c - allow concurrent queries when cache enabled (#42) (11 hours ago) <Rob Cowart>
```