### PR TITLE
backport a JRuby 9.1.16.0 stdlib resolv.rb patch on earlier versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.11
+  - Fixed JRuby resolver bug for versions prior to 9.1.16.0 [#45](https://github.com/logstash-plugins/logstash-filter-dns/pull/45)
+
 ## 3.0.10
   - Log timeouts as warn instead of error #43
   - Allow concurrent queries when cache enabled #42

--- a/lib/logstash/filters/dns.rb
+++ b/lib/logstash/filters/dns.rb
@@ -4,6 +4,7 @@ require "logstash/namespace"
 require "lru_redux"
 require "resolv"
 require "timeout"
+require "logstash/filters/resolv_patch"
 
 java_import 'java.net.IDN'
 

--- a/lib/logstash/filters/resolv_patch.rb
+++ b/lib/logstash/filters/resolv_patch.rb
@@ -1,0 +1,35 @@
+require "resolv"
+
+# ref: https://github.com/logstash-plugins/logstash-filter-dns/issues/40
+#
+# JRuby 9k versions prior to 9.1.16.0 have a bug which crashes IP address
+# resolution after 64k unique IP addresses resolutions.
+#
+# Note that the oldest JRuby version in LS 6 is 9.1.13.0 and
+# JRuby 1.7.25 and 1.7.27 (the 2 versions used across LS 5) are not affected by this bug.
+#
+# The code below is copied from JRuby 9.1.16.0 resolv.rb:
+# https://github.com/jruby/jruby/blob/9.1.16.0/lib/ruby/stdlib/resolv.rb#L775-L784
+
+JRUBY_GEM_VERSION = Gem::Version.new(JRUBY_VERSION)
+
+if JRUBY_GEM_VERSION >= Gem::Version.new("9.1.13.0") && JRUBY_GEM_VERSION < Gem::Version.new("9.1.16.0")
+  class Resolv
+    class DNS
+      class Requester
+        class UnconnectedUDP
+          def sender(msg, data, host, port=Port)
+            sock = @socks_hash[host.index(':') ? "::" : "0.0.0.0"]
+            return nil if !sock
+            service = [IPAddr.new(host), port]
+            id = DNS.allocate_request_id(service[0], service[1])
+            request = msg.encode
+            request[0,2] = [id].pack('n')
+            return @senders[[service, id]] =
+                Sender.new(request, data, sock, host, port)
+          end
+        end
+      end
+    end
+  end
+end

--- a/logstash-filter-dns.gemspec
+++ b/logstash-filter-dns.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-dns'
-  s.version         = '3.0.10'
+  s.version         = '3.0.11'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Performs a standard or reverse DNS lookup"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Fixes #40 

The installed JRuby version 9.1.13.0 has a bug in the stdlib resolv.rb that has been fixed in 9.1.16.0

This bug result in the resolver hanging after 64k unique IP resolutions.

This patch is also submitted in core elastic/logstash/pull/9750. I do not see a problem having the patch in the 2 places, this one here will apply on any LS version and eventually if a patched LS version is used it wont cause problem since the patching is guarded using a version check.

I testing this locally, see #40.