### PR TITLE
backport patch to resolv for underqualified domain names

### DIFF
--- a/lib/logstash/filters/dns.rb
+++ b/lib/logstash/filters/dns.rb
@@ -4,7 +4,7 @@ require "logstash/namespace"
 require "lru_redux"
 require "resolv"
 require "timeout"
-require "logstash/filters/resolv_patch"
+require "logstash/filters/dns/resolv_patch"
 
 java_import 'java.net.IDN'
 


### PR DESCRIPTION
In the Ruby stdlib that ships with JRubies < 9.0, there was a bug that prevented underqualified domain names from resolving (that is, domain names with fewer dots in them than the configured minimum, which defaults to 1).

Effectively this prevented _unqualified_ domain names (e.g., dot-less domain names registered with a dns server like dnsmasq, or even `localhost`) from resolving.

If applicable to the runtime, this patch backports a patch from https://bugs.ruby-lang.org/issues/10412

***

It also clean up the `resolv_patch.rb` file in two ways:
 - it moves it into the `logstash/filter/dns` directory to avoid it being loaded accidentally (and perhaps out-of-order) by another plugin
 - it uses local variables to avoid setting global top-level constants, which could interfere with other plugins