### PR TITLE
Handle more errors gracefully

### DIFF
--- a/lib/logstash/filters/dns.rb
+++ b/lib/logstash/filters/dns.rb
@@ -166,6 +166,14 @@ class LogStash::Filters::DNS < LogStash::Filters::Base
         @logger.error("DNS: Encountered SocketError.",
                       :field => field, :value => raw, :message => e.message)
         return
+      rescue Java::JavaLang::IllegalArgumentException => e
+        @logger.error("DNS: Unable to parse address.",
+                      :field => field, :value => raw, :message => e.message)
+        return
+      rescue => e
+        @logger.error("DNS: Unexpected Error.",
+                      :field => field, :value => raw, :message => e.message)
+        return
       end
 
       if @action == "replace"
@@ -236,6 +244,14 @@ class LogStash::Filters::DNS < LogStash::Filters::Base
         return
       rescue SocketError => e
         @logger.error("DNS: Encountered SocketError.",
+                      :field => field, :value => raw, :message => e.message)
+        return
+      rescue Java::JavaLang::IllegalArgumentException => e
+        @logger.error("DNS: Unable to parse address.",
+                      :field => field, :value => raw, :message => e.message)
+        return
+      rescue => e
+        @logger.error("DNS: Unexpected Error.",
                       :field => field, :value => raw, :message => e.message)
         return
       end

--- a/spec/filters/dns_spec.rb
+++ b/spec/filters/dns_spec.rb
@@ -389,6 +389,14 @@ describe LogStash::Filters::DNS do
         end
       end
 
+      context 'with a label too long' do
+        let(:host) { "#{'0' * 64}.com" }
+
+        it 'should not raise' do
+          subject.filter(event)
+        end
+      end
+
       context "when failing temporarily" do
         before(:each) do
           allow(subject).to receive(:getaddress) do


### PR DESCRIPTION
Certain classes of errors could cause the plugin to crash (for
example trying to resolve an address with a label with > 63 characters)
This commit adds some more error handling to log error and skip the 
event
