### PR TITLE
add search domains to nameserver configuration

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -55,7 +55,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-hit_cache_ttl>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-hostsfile>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-max_retries>> |<<number,number>>|No
-| <<plugins-{type}s-{plugin}-nameserver>> |<<array,array>>|No
+| <<plugins-{type}s-{plugin}-nameserver>> |<<hash,hash>>|No
 | <<plugins-{type}s-{plugin}-resolve>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-reverse>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-timeout>> |<<number,number>>|No
@@ -126,10 +126,24 @@ number of times to retry a failed resolve/reverse
 [id="plugins-{type}s-{plugin}-nameserver"]
 ===== `nameserver` 
 
-  * Value type is <<array,array>>
+  * Value type is <<hash,hash>>, and is composed of:
+    * a required `address` key, whose value is either a <<string,string>> or an <<array,array>>, representing one or more nameserver ip addresses
+    * an optional `search` key, whose value is either a <<string,string>> or an <<array,array>>, representing between one and six search domains (e.g., with search domain `com`, a query for `example` will match DNS entries for `example.com`)
+    * an optional `ndots` key, used in conjunction with `search`, whose value is a <<number,number>>, representing the minimum number of dots in a domain name being resolved that will _prevent_ the search domains from being used (default `1`; this option is rarely needed)
+  * For backward-compatibility, values of <<string,string>> and <<array,array>> are also accepted, representing one or more nameserver ip addresses _without_ search domains.
   * There is no default value for this setting.
 
-Use custom nameserver(s). For example: `["8.8.8.8", "8.8.4.4"]`
+Use custom nameserver(s). For example:
+
+[source]
+    filter {
+      dns {
+        nameserver => {
+          address => ["8.8.8.8", "8.8.4.4"]
+          search  => ["internal.net"]
+        }
+      }
+    }
 
 [id="plugins-{type}s-{plugin}-resolve"]
 ===== `resolve` 

--- a/spec/filters/dns_spec.rb
+++ b/spec/filters/dns_spec.rb
@@ -298,6 +298,25 @@ describe LogStash::Filters::DNS do
       end
     end
 
+    describe 'dns resolve lookup with search' do
+      config <<-CONFIG
+        filter {
+          dns {
+            resolve => ["host"]
+            action => "replace"
+            nameserver => {
+              address => ["127.0.0.99", "8.8.8.8"]
+              search  => "databits.net"
+            }
+          }
+        }
+      CONFIG
+
+      sample("host" => "carrera") do
+        insist { subject.get("host") } == "199.192.228.250"
+      end
+    end
+
     describe "failed cache" do
 
       let(:subject) { LogStash::Filters::DNS.new(config) }
@@ -410,7 +429,80 @@ describe LogStash::Filters::DNS do
     end
   end
 
-  describe "with nameserver integration" do
+  describe "with nameserver configuration" do
+    subject(:dns_filter_plugin) { LogStash::Filters::DNS.new(config) }
+
+    before(:each) do
+      allow(Resolv::DNS).to receive(:new).and_call_original
+    end
+
+    context 'nameserver specified as a string' do
+      let(:config) { { "nameserver" => "8.8.8.8" } }
+
+      it 'sets up the expected Resolv::DNS' do
+        dns_filter_plugin.register
+
+        expect(Resolv::DNS).to have_received(:new).with(:nameserver => ["8.8.8.8"], :search => [], :ndots => 1)
+      end
+    end
+
+    context 'nameserver specified as an array of strings' do
+      let(:config) { { "nameserver" => ["8.8.8.8", "8.8.4.4"] } }
+
+      it 'sets up the expected Resolv::DNS' do
+        dns_filter_plugin.register
+
+        expect(Resolv::DNS).to have_received(:new).with(:nameserver => ["8.8.8.8", "8.8.4.4"], :search => [], :ndots => 1)
+      end
+    end
+
+    context 'nameserver specified as a hash' do
+      context 'with only string address' do
+        let(:config) { { "nameserver" => { "address" => "8.8.8.8" } } }
+
+        it 'sets up the expected Resolv::DNS' do
+          dns_filter_plugin.register
+
+          expect(Resolv::DNS).to have_received(:new).with(:nameserver => ["8.8.8.8"], :search => [], :ndots => 1)
+        end
+      end
+      context 'with only array address' do
+        let(:config) { { "nameserver" => { "address" => ["8.8.8.8", "8.8.4.4"] } } }
+
+        it 'sets up the expected Resolv::DNS' do
+          dns_filter_plugin.register
+
+          expect(Resolv::DNS).to have_received(:new).with(:nameserver => ["8.8.8.8", "8.8.4.4"], :search => [], :ndots => 1)
+        end
+      end
+      context 'with search domains' do
+        let(:config) do
+          {
+            "nameserver" => {
+              "address" => ["127.0.0.1"],
+              "search" => search_domains
+            }
+          }
+        end
+
+        {
+          "string" => "internal.net",
+          "array of strings" => ["internal.net", "internal1.com"]
+        }.each do |desc, search_domains_arg|
+          let(:search_domains) { search_domains_arg }
+          context "as #{desc}" do
+            it 'sets up the expected Resolv::DNS' do
+              dns_filter_plugin.register
+
+              expect(Resolv::DNS).to have_received(:new).with(:nameserver => ["127.0.0.1"], :search => Array(search_domains), :ndots => 1)
+            end
+          end
+        end
+      end
+    end
+  end
+
+  describe "with hostsfile integration" do
     describe "lookup using fixture hosts file" do
       let(:subject) { LogStash::Filters::DNS.new(config) }
       let(:hostsfile) { File.join(File.dirname(__FILE__), "..", "fixtures", "hosts") }


### PR DESCRIPTION
This change adds search domains to a nameserver configuration.

To do so, it changes the `nameserver` directive to accept a hash containing:
 - a required `address` key, holding either a string or an array representing ip addresses
 - an optional `search` key, holding either a string or an array representing up to six search domains (a limitation of the underlying resolv library)
 - an optional `ndots` key, holding a number (defaulting to 1), representing the minimum number of dots in a query that will _not_ resolve through the given search domains.

For backward compatibility, we continue to support a string or array argument for `nameserver`, representing ip addresses of nameservers to use _without_ search domains.

***

See: #32 