### PR TITLE
Add DNS timeout tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.0
+  - TODO
+
 ## 3.0.13
   - Fixed JRuby resolver bug for versions after to 9.2.0.0 [#51](https://github.com/logstash-plugins/logstash-filter-dns/pull/51)
 

--- a/logstash-filter-dns.gemspec
+++ b/logstash-filter-dns.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-dns'
-  s.version         = '3.0.13'
+  s.version         = '3.1.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Performs a standard or reverse DNS lookup"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/dns_spec.rb
+++ b/spec/filters/dns_spec.rb
@@ -298,6 +298,82 @@ describe LogStash::Filters::DNS do
       end
     end
 
+    describe "dns forward timeout" do
+
+      let(:subject) { LogStash::Filters::DNS.new(config) }
+
+      before(:each) do
+        allow(subject).to receive(:getaddress).and_raise Timeout::Error
+        subject.register
+        subject.filter(event)
+      end
+
+      context "when using the default tag" do
+        let(:config) { { "resolve" => ["message"] } }
+        let(:event) { LogStash::Event.new("message" => "carrera.databits.net") }
+
+        it "should add the default DNS timeout tag" do
+          expect(event.get("tags")).to eq(["_dnstimeout"])
+        end
+      end
+
+      context "when using a custom tag" do
+        let(:config) { { "resolve" => ["message"], "tag_on_timeout" => ["dns_custom_timeout"] } }
+        let(:event) { LogStash::Event.new("message" => "carrera.databits.net") }
+
+        it "should add the custom DNS timeout tag" do
+          expect(event.get("tags")).to eq(["dns_custom_timeout"])
+        end
+      end
+
+      context "when using no tags" do
+        let(:config) { { "resolve" => ["message"], "tag_on_timeout" => [] } }
+        let(:event) { LogStash::Event.new("message" => "carrera.databits.net") }
+
+        it "should not add any failure tags" do
+          expect(event.get("tags")).to eq(nil)
+        end
+      end
+    end
+
+    describe "dns reverse timeout" do
+
+      let(:subject) { LogStash::Filters::DNS.new(config) }
+
+      before(:each) do
+        allow(subject).to receive(:getname).and_raise Timeout::Error
+        subject.register
+        subject.filter(event)
+      end
+
+      context "when using the default tag" do
+        let(:config) { { "reverse" => ["message"] } }
+        let(:event) { LogStash::Event.new("message" => "127.0.0.1") }
+
+        it "should add the default DNS timeout tag" do
+          expect(event.get("tags")).to eq(["_dnstimeout"])
+        end
+      end
+
+      context "when using a custom tag" do
+        let(:config) { { "reverse" => ["message"], "tag_on_timeout" => ["dns_custom_timeout"] } }
+        let(:event) { LogStash::Event.new("message" => "127.0.0.1") }
+
+        it "should add the custom DNS timeout tag" do
+          expect(event.get("tags")).to eq(["dns_custom_timeout"])
+        end
+      end
+
+      context "when using no tags" do
+        let(:config) { { "reverse" => ["message"], "tag_on_timeout" => [] } }
+        let(:event) { LogStash::Event.new("message" => "127.0.0.1") }
+
+        it "should not add any failure tags" do
+          expect(event.get("tags")).to eq(nil)
+        end
+      end
+    end
+
     describe "failed cache" do
 
       let(:subject) { LogStash::Filters::DNS.new(config) }


### PR DESCRIPTION
This PR adds a tag whenever a DNS lookup times out and changes the related logging level to `debug`, fixing #47.

I'm marking this PR as WIP because I like the option of adding a tag on each kind of failure (#24) more, but I'm not fully sure if I should just add a generic "failure" tag for each kind of error that might occur (DNS lookup failure/timeout error...) or if there should be a way to associate each kind of failure to a specific tag.