### PR TITLE
switch to openjdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,5 @@ matrix:
   fast_finish: true
 install: true
 script: ci/build.sh
-jdk: oraclejdk8
+jdk: openjdk8
 before_install: gem install bundler -v '< 2'


### PR DESCRIPTION
builds are failing since Travis moved to default distribution of Xenial; builds can no longer use oraclejdk8.
