### PR TITLE
doc on the nameserver option for relying on /etc/resolv.conf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.14
+  - Added documentation on the `nameserver` option for relying on `/etc/resolv.conf` to configure the resolver
+
 ## 3.0.13
   - Fixed JRuby resolver bug for versions after to 9.2.0.0 [#51](https://github.com/logstash-plugins/logstash-filter-dns/pull/51)
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -129,7 +129,13 @@ number of times to retry a failed resolve/reverse
   * Value type is <<array,array>>
   * There is no default value for this setting.
 
-Use custom nameserver(s). For example: `["8.8.8.8", "8.8.4.4"]`
+Use custom nameserver(s). For example: `["8.8.8.8", "8.8.4.4"]`.
+If `nameserver` is not specified then `/etc/resolv.conf` will be read to
+configure the resolver using the `nameserver`, `domain`,
+`search` and `ndots` directives in `/etc/resolv.conf`.
+
+Relying on `/etc/resolv.conf` can be useful to provide a domains
+search list to resolve underqualified host names for example.
 
 [id="plugins-{type}s-{plugin}-resolve"]
 ===== `resolve` 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -134,8 +134,9 @@ If `nameserver` is not specified then `/etc/resolv.conf` will be read to
 configure the resolver using the `nameserver`, `domain`,
 `search` and `ndots` directives in `/etc/resolv.conf`.
 
-Relying on `/etc/resolv.conf` can be useful to provide a domains
-search list to resolve underqualified host names for example.
+Note that nameservers normally resolve FQDNs and relying on `/etc/resolv.conf`
+can be useful to provide a domains search list to resolve underqualified
+host names for example.
 
 [id="plugins-{type}s-{plugin}-resolve"]
 ===== `resolve` 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -134,9 +134,9 @@ If `nameserver` is not specified then `/etc/resolv.conf` will be read to
 configure the resolver using the `nameserver`, `domain`,
 `search` and `ndots` directives in `/etc/resolv.conf`.
 
-Note that nameservers normally resolve FQDNs and relying on `/etc/resolv.conf`
-can be useful to provide a domains search list to resolve underqualified
-host names for example.
+Note that nameservers normally resolve fully qualified domain names (FQDN)
+and relying on `/etc/resolv.conf` can be useful to provide a domains search
+list to resolve underqualified host names for example.
 
 [id="plugins-{type}s-{plugin}-resolve"]
 ===== `resolve` 

--- a/lib/logstash/filters/dns.rb
+++ b/lib/logstash/filters/dns.rb
@@ -51,8 +51,9 @@ class LogStash::Filters::DNS < LogStash::Filters::Base
   # configure the resolver using the `nameserver`, `domain`,
   # `search` and `ndots` directives in `/etc/resolv.conf`.
   #
-  # Relying on `/etc/resolv.conf` can be useful to provide a domains
-  # search list to resolve underqualified host names for example.
+  # Note that nameservers normally resolve FQDNs and relying on `/etc/resolv.conf`
+  # can be useful to provide a domains search list to resolve underqualified
+  # host names for example.
   config :nameserver, :validate => :array
 
   # `resolv` calls will be wrapped in a timeout instance

--- a/lib/logstash/filters/dns.rb
+++ b/lib/logstash/filters/dns.rb
@@ -51,9 +51,9 @@ class LogStash::Filters::DNS < LogStash::Filters::Base
   # configure the resolver using the `nameserver`, `domain`,
   # `search` and `ndots` directives in `/etc/resolv.conf`.
   #
-  # Note that nameservers normally resolve FQDNs and relying on `/etc/resolv.conf`
-  # can be useful to provide a domains search list to resolve underqualified
-  # host names for example.
+  # Note that nameservers normally resolve fully qualified domain names (FQDN)
+  # and relying on `/etc/resolv.conf` can be useful to provide a domains search
+  # list to resolve underqualified host names for example.
   config :nameserver, :validate => :array
 
   # `resolv` calls will be wrapped in a timeout instance

--- a/lib/logstash/filters/dns.rb
+++ b/lib/logstash/filters/dns.rb
@@ -46,7 +46,13 @@ class LogStash::Filters::DNS < LogStash::Filters::Base
   # specified under `reverse` and `resolve`.
   config :action, :validate => [ "append", "replace" ], :default => "append"
 
-  # Use custom nameserver(s). For example: `["8.8.8.8", "8.8.4.4"]`
+  # Use custom nameserver(s). For example: `["8.8.8.8", "8.8.4.4"]`.
+  # If `nameserver` is not specified then `/etc/resolv.conf` will be read to
+  # configure the resolver using the `nameserver`, `domain`,
+  # `search` and `ndots` directives in `/etc/resolv.conf`.
+  #
+  # Relying on `/etc/resolv.conf` can be useful to provide a domains
+  # search list to resolve underqualified host names for example.
   config :nameserver, :validate => :array
 
   # `resolv` calls will be wrapped in a timeout instance

--- a/logstash-filter-dns.gemspec
+++ b/logstash-filter-dns.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-dns'
-  s.version         = '3.0.13'
+  s.version         = '3.0.14'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Performs a standard or reverse DNS lookup"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Added doc for the `nameserver` option to rely on `/etc/resolv.conf`. Bumped version to 3.0.14.

This is currently a way to support domain search list to resolve underqualified host names using the `/etc/resolv.conf` `search` and `ndots` directives. 

#50 should add this capability as explicit options soon.