### PR TITLE
add search domains to nameserver configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.0
+  - Added search domains to the `nameserver` option [#56](https://github.com/logstash-plugins/logstash-filter-dns/pull/56)
+
 ## 3.0.14
   - Added documentation on the `nameserver` option for relying on `/etc/resolv.conf` to configure the resolver
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -55,7 +55,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-hit_cache_ttl>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-hostsfile>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-max_retries>> |<<number,number>>|No
-| <<plugins-{type}s-{plugin}-nameserver>> |<<array,array>>|No
+| <<plugins-{type}s-{plugin}-nameserver>> |<<hash,hash>>|No
 | <<plugins-{type}s-{plugin}-resolve>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-reverse>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-timeout>> |<<number,number>>|No
@@ -126,17 +126,28 @@ number of times to retry a failed resolve/reverse
 [id="plugins-{type}s-{plugin}-nameserver"]
 ===== `nameserver` 
 
-  * Value type is <<array,array>>
+  * Value type is <<hash,hash>>, and is composed of:
+    * a required `address` key, whose value is either a <<string,string>> or an <<array,array>>, representing one or more nameserver ip addresses
+    * an optional `search` key, whose value is either a <<string,string>> or an <<array,array>>, representing between one and six search domains (e.g., with search domain `com`, a query for `example` will match DNS entries for `example.com`)
+    * an optional `ndots` key, used in conjunction with `search`, whose value is a <<number,number>>, representing the minimum number of dots in a domain name being resolved that will _prevent_ the search domains from being used (default `1`; this option is rarely needed)
+  * For backward-compatibility, values of <<string,string>> and <<array,array>> are also accepted, representing one or more nameserver ip addresses _without_ search domains.
   * There is no default value for this setting.
 
-Use custom nameserver(s). For example: `["8.8.8.8", "8.8.4.4"]`.
+Use custom nameserver(s). For example:
+
+[source]
+    filter {
+      dns {
+        nameserver => {
+          address => ["8.8.8.8", "8.8.4.4"]
+          search  => ["internal.net"]
+        }
+      }
+    }
+
 If `nameserver` is not specified then `/etc/resolv.conf` will be read to
 configure the resolver using the `nameserver`, `domain`,
 `search` and `ndots` directives in `/etc/resolv.conf`.
-
-Note that nameservers normally resolve fully qualified domain names (FQDN)
-and relying on `/etc/resolv.conf` can be useful to provide a domains search
-list to resolve underqualified host names for example.
 
 [id="plugins-{type}s-{plugin}-resolve"]
 ===== `resolve` 

--- a/lib/logstash/filters/dns.rb
+++ b/lib/logstash/filters/dns.rb
@@ -46,14 +46,25 @@ class LogStash::Filters::DNS < LogStash::Filters::Base
   # specified under `reverse` and `resolve`.
   config :action, :validate => [ "append", "replace" ], :default => "append"
 
-  # Use custom nameserver(s). For example: `["8.8.8.8", "8.8.4.4"]`.
+  # Use custom nameserver(s). For example:
+  #    filter {
+  #      dns {
+  #         nameserver => {
+  #          address => ["8.8.8.8", "8.8.4.4"]
+  #          search  => ["internal.net"]
+  #        }
+  #      }
+  #    }
+  #
+  # nameserver is a hash with the following key:
+  #   * a required `address` key, whose value is either a <<string,string>> or an <<array,array>>, representing one or more nameserver ip addresses
+  #   * an optional `search` key, whose value is either a <<string,string>> or an <<array,array>>, representing between one and six search domains (e.g., with search domain `com`, a query for `example` will match DNS entries for `example.com`)
+  #   * an optional `ndots` key, used in conjunction with `search`, whose value is a <<number,number>>, representing the minimum number of dots in a domain name being resolved that will _prevent_ the search domains from being used (default `1`; this option is rarely needed)
+  #   * For backward-compatibility, string ans arrays values are also accepted, representing one or more nameserver ip addresses _without_ search domains.
+  #
   # If `nameserver` is not specified then `/etc/resolv.conf` will be read to
   # configure the resolver using the `nameserver`, `domain`,
   # `search` and `ndots` directives in `/etc/resolv.conf`.
-  #
-  # Note that nameservers normally resolve fully qualified domain names (FQDN)
-  # and relying on `/etc/resolv.conf` can be useful to provide a domains search
-  # list to resolve underqualified host names for example.
   config :nameserver, :validate => :array
 
   # `resolv` calls will be wrapped in a timeout instance
@@ -142,7 +153,7 @@ class LogStash::Filters::DNS < LogStash::Filters::Base
 
     ndots      = nameserver_hash.delete('ndots') || 1
     ndots      = Integer(ndots)
-    ndots <= 0 && fail(LogStash::ConfigurationError, "DNS Filter: ndots must be positive (got `#{@nameserver}`)")
+    ndots <= 0 && fail(LogStash::ConfigurationError, "DNS Filter: `ndots` must be positive (got `#{@nameserver}`)")
 
     fail(LogStash::ConfigurationError, "Unknown `nameserver` argument(s): #{nameserver_hash}") unless nameserver_hash.empty?
 

--- a/lib/logstash/filters/dns.rb
+++ b/lib/logstash/filters/dns.rb
@@ -125,7 +125,32 @@ class LogStash::Filters::DNS < LogStash::Filters::Base
 
   def build_user_dns_resolver
     return [] if @nameserver.nil? || @nameserver.empty?
-    [::Resolv::DNS.new(:nameserver => @nameserver, :search => [], :ndots => 1)]
+
+    [::Resolv::DNS.new(normalised_nameserver)]
+  end
+
+  def normalised_nameserver
+    nameserver_hash = @nameserver.kind_of?(Hash) ? @nameserver.dup : { 'address' => @nameserver }
+
+    nameserver = nameserver_hash.delete('address') || fail(LogStash::ConfigurationError, "DNS Filter: `nameserver` hash must include `address` (got `#{@nameserver}`)")
+    nameserver = Array(nameserver).map(&:to_s)
+    nameserver.empty? && fail(LogStash::ConfigurationError, "DNS Filter: `nameserver` addresses, when specified, cannot be empty (got `#{@nameserver}`)")
+
+    search     = nameserver_hash.delete('search') || []
+    search     = Array(search).map(&:to_s)
+    search.size > 6 && fail(LogStash::ConfigurationError, "DNS Filter: A maximum of 6 `search` domains are accepted (got `#{@nameserver}`)")
+
+    ndots      = nameserver_hash.delete('ndots') || 1
+    ndots      = Integer(ndots)
+    ndots <= 0 && fail(LogStash::ConfigurationError, "DNS Filter: ndots must be positive (got `#{@nameserver}`)")
+
+    fail(LogStash::ConfigurationError, "Unknown `nameserver` argument(s): #{nameserver_hash}") unless nameserver_hash.empty?
+
+    {
+      :nameserver => nameserver,
+      :search     => search,
+      :ndots      => ndots
+    }
   end
 
   def resolve(event)

--- a/logstash-filter-dns.gemspec
+++ b/logstash-filter-dns.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-dns'
-  s.version         = '3.0.14'
+  s.version         = '3.1.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Performs a standard or reverse DNS lookup"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
This is a reboot of #50 by @yaauie 

This change adds search domains to a nameserver configuration.

To do so, it changes the `nameserver` directive to accept a hash containing:
 - a required `address` key, holding either a string or an array representing ip addresses
 - an optional `search` key, holding either a string or an array representing up to six search domains (a limitation of the underlying resolv library)
 - an optional `ndots` key, holding a number (defaulting to 1), representing the minimum number of dots in a query that will _not_ resolve through the given search domains.

For backward compatibility, we continue to support a string or array argument for `nameserver`, representing ip addresses of nameservers to use _without_ search domains.

See: #32 
