### PR TITLE
restrict JRuby resolv.rb patch to versions prior to 9.2.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.2
+  - Added restriction on JRuby resolv.rb patch to versions prior to 9.2.9.0 [#58](https://github.com/logstash-plugins/logstash-filter-dns/pull/58)
+
 ## 3.1.1
   - Fixed asciidoc formatting for unordered list and a code sample in docs[#57](https://github.com/logstash-plugins/logstash-filter-dns/pull/57)
 

--- a/lib/logstash/filters/dns/resolv_patch.rb
+++ b/lib/logstash/filters/dns/resolv_patch.rb
@@ -35,12 +35,12 @@ end
 
 # ref: https://github.com/logstash-plugins/logstash-filter-dns/issues/51
 #
-# JRuby versions starting at 9.2.0.0 have a bug caused by an upstream Ruby stdlib resolv.rb bug.
+# JRuby versions starting at 9.2.0.0 and prior to 9.2.9.0 have a bug caused by an upstream Ruby stdlib resolv.rb bug.
 # This bug is essentially the same as the previous above bug where there is a leak between the
 # DNS.allocate_request_id/DNS.free_request_id.
-# This fix is required because starting at JRuby 9.2.0.0 the resolv.rb code was updated from the
+# This fix is required because starting at JRuby 9.2.0.0 and prior to 9.2.9.0 the resolv.rb code was updated from the
 # upstream Ruby stdlib code and the previous patch cannot be applied. Also this fix is better than the previous one.
-if jruby_gem_version >= Gem::Version.new("9.2.0.0")
+if jruby_gem_version >= Gem::Version.new("9.2.0.0") && jruby_gem_version < Gem::Version.new("9.2.9.0")
   # save verbose level and mute the "warning: already initialized constant"
   warn_level = $VERBOSE
   $VERBOSE = nil

--- a/lib/logstash/filters/dns/resolv_patch.rb
+++ b/lib/logstash/filters/dns/resolv_patch.rb
@@ -40,7 +40,7 @@ end
 # DNS.allocate_request_id/DNS.free_request_id.
 # This fix is required because starting at JRuby 9.2.0.0 and prior to 9.2.9.0 the resolv.rb code was updated from the
 # upstream Ruby stdlib code and the previous patch cannot be applied. Also this fix is better than the previous one.
-if jruby_gem_version >= Gem::Version.new("9.2.0.0") && jruby_gem_version < Gem::Version.new("9.2.9.0")
+if Gem::Requirement.new([">= 9.2.0.0", "< 9.2.9.0"]).satisfied_by?(jruby_gem_version)
   # save verbose level and mute the "warning: already initialized constant"
   warn_level = $VERBOSE
   $VERBOSE = nil

--- a/logstash-filter-dns.gemspec
+++ b/logstash-filter-dns.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-dns'
-  s.version         = '3.1.1'
+  s.version         = '3.1.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Performs a standard or reverse DNS lookup"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Similar to elastic/logstash#11330, per #11281 we upgrade logstash to JRuby to v9.2.9.0 which includes the `resolv.rb` fix in jruby/jruby#5722  which makes our patch now unnecessary for logstash with JRuby version starting at 9.2.9.0.
