### PR TITLE
handle lookup misses without exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.3
+  - Fixed an issue where each missed lookup could result in unreclaimed memory ([jruby bug](https://github.com/jruby/jruby/issues/6015)) by handling lookup misses without raising exceptions [#61](https://github.com/logstash-plugins/logstash-filter-dns/pull/61)
+
 ## 3.1.2
   - Added restriction on JRuby resolv.rb patch to versions prior to 9.2.9.0 [#58](https://github.com/logstash-plugins/logstash-filter-dns/pull/58)
 

--- a/logstash-filter-dns.gemspec
+++ b/logstash-filter-dns.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-dns'
-  s.version         = '3.1.2'
+  s.version         = '3.1.3'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Performs a standard or reverse DNS lookup"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Resolves: logstash-plugins/logstash-filter-dns#60:

> The `Resolv` APIs this plugin uses throw exceptions when there is no name associated with an address (or _vice versa_; read: lookup _miss_, not lookup _failure_), and our implmentation relies on these costly exceptions for flow control (`Resolv#getname(address)`, `Resolv#getaddress(name)`).
>
> But `Resolv` also provides public APIs that treat a lookup _misses_ as non-exceptional (`Resolv#each_name(address,&block)`, `Resolv#each_address(name,&block)`, which still handle lookup _failure_ exceptionally). I believe that we should look into using these APIs, and will need to modify our implementation to handle these lookup misses in the normal (non-exceptional) flow control.