### PR TITLE
Replace Timeout::timeout block with `Resolv::DNS::timeouts=`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,9 @@ matrix:
   - rvm: jruby-9.1.13.0
     env: LOGSTASH_BRANCH=master
   - rvm: jruby-9.1.13.0
-    env: LOGSTASH_BRANCH=7.0
+    env: LOGSTASH_BRANCH=7.5
   - rvm: jruby-9.1.13.0
-    env: LOGSTASH_BRANCH=6.7
-  - rvm: jruby-9.1.13.0
-    env: LOGSTASH_BRANCH=6.6
-  - rvm: jruby-1.7.27
-    env: LOGSTASH_BRANCH=5.6
+    env: LOGSTASH_BRANCH=6.8
   fast_finish: true
 install: true
 script: ci/build.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.4
+  - Replaced Timeout::timeout block with `Resolv::DNS::timeouts=` [#62](https://github.com/logstash-plugins/logstash-filter-dns/pull/62)
+  - Added restriction for ruby version > 2.0, effectively making Logstash 6.x+ a requirement [#62](https://github.com/logstash-plugins/logstash-filter-dns/pull/62)
+
 ## 3.1.3
   - Fixed an issue where each missed lookup could result in unreclaimed memory ([jruby bug](https://github.com/jruby/jruby/issues/6015)) by handling lookup misses without raising exceptions [#61](https://github.com/logstash-plugins/logstash-filter-dns/pull/61)
 

--- a/logstash-filter-dns.gemspec
+++ b/logstash-filter-dns.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-dns'
-  s.version         = '3.1.3'
+  s.version         = '3.1.4'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Performs a standard or reverse DNS lookup"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -9,6 +9,9 @@ Gem::Specification.new do |s|
   s.email           = 'info@elastic.co'
   s.homepage        = "http://www.elastic.co/guide/en/logstash/current/index.html"
   s.require_paths = ["lib"]
+
+  # This effectively requires Logstash >= 6.x
+  s.required_ruby_version = '>= 2.0.0'
 
   # Files
   s.files = Dir["lib/**/*","spec/**/*","*.gemspec","*.md","CONTRIBUTORS","Gemfile","LICENSE","NOTICE.TXT", "vendor/jar-dependencies/**/*.jar", "vendor/jar-dependencies/**/*.rb", "VERSION", "docs/**/*"]

--- a/spec/filters/dns_spec.rb
+++ b/spec/filters/dns_spec.rb
@@ -425,7 +425,7 @@ describe LogStash::Filters::DNS do
             @try ||= 0
             if @try < 2
               @try = @try + 1
-              raise Timeout::Error
+              raise SocketError
             else
               "127.0.0.1"
             end

--- a/spec/filters/dns_spec.rb
+++ b/spec/filters/dns_spec.rb
@@ -2,6 +2,8 @@
 require "logstash/devutils/rspec/spec_helper"
 require "logstash/filters/dns"
 require "resolv"
+require "logstash/filters/dns/resolv_patch"
+
 
 describe LogStash::Filters::DNS do
   describe "with stubbed Resolv" do
@@ -377,7 +379,7 @@ describe LogStash::Filters::DNS do
 
       context "when failing permanently" do
         before(:each) do
-          allow(subject).to receive(:getaddress).and_raise(Timeout::Error)
+          allow(subject).to receive(:getaddress).and_raise(Resolv::ResolvTimeout)
         end
 
         it "should fail a resolve after max_retries" do
@@ -385,7 +387,24 @@ describe LogStash::Filters::DNS do
           subject.filter(event)
         end
 
-        it "should cache the timeout" do
+        it "should cache the failure" do
+          expect do
+            subject.filter(event)
+          end.to change { subject.failed_cache[host] }.from(nil).to(true)
+        end
+      end
+
+      context "when unable to resolve an address" do
+        before(:each) do
+          allow(subject).to receive(:getaddress).and_return(nil)
+        end
+
+        it "should fail a resolve after max_retries" do
+          expect(subject).to receive(:getaddress).once
+          subject.filter(event)
+        end
+
+        it "should cache the failure" do
           expect do
             subject.filter(event)
           end.to change { subject.failed_cache[host] }.from(nil).to(true)
@@ -527,7 +546,7 @@ describe LogStash::Filters::DNS do
         # Resolv::DNS.new will be called without arguments thus reading /etc/resolv.conf
         # for its configuration which is the desired behaviour for backward compatibility
 
-        expect(Resolv::DNS).to receive(:new).once.with(no_args)
+        expect(Resolv::DNS).to receive(:new).once.with(nil).and_call_original
         dns_filter_plugin.register
       end
     end


### PR DESCRIPTION
This commit replaces the use of a `Timeout::Timeout` block with
the '#timeouts=' functionality added to the Resolv::DNS class
in Juby-9k.
