### PR TITLE
Clarify cache size 0 meaning

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -79,7 +79,7 @@ specified under `reverse` and `resolve`.
 ===== `failed_cache_size` 
 
   * Value type is <<number,number>>
-  * Default value is `0`
+  * Default value is `0` (cache disabled)
 
 cache size for failed requests
 
@@ -95,7 +95,7 @@ how long to cache failed requests (in seconds)
 ===== `hit_cache_size` 
 
   * Value type is <<number,number>>
-  * Default value is `0`
+  * Default value is `0` (cache disabled)
 
 set the size of cache for successful requests
 


### PR DESCRIPTION
I wasn't sure whether `hit_cache_size` 0 meant that the cache was disabled, or that the cache size was unlimited.  https://github.com/logstash-plugins/logstash-filter-dns/blob/master/lib/logstash/filters/dns.rb#L100 indicates that 0 means disabled, so I added it to the documentation.
