### PR TITLE
prevent crash for non-string values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.5
+  - Fixed an issue where a non-string value existing in the resolve/reverse field could cause the plugin to crash
+
 ## 3.1.4
   - Replaced Timeout::timeout block with `Resolv::DNS::timeouts=` [#62](https://github.com/logstash-plugins/logstash-filter-dns/pull/62)
   - Added restriction for ruby version > 2.0, effectively making Logstash 6.x+ a requirement [#62](https://github.com/logstash-plugins/logstash-filter-dns/pull/62)

--- a/lib/logstash/filters/dns.rb
+++ b/lib/logstash/filters/dns.rb
@@ -194,6 +194,11 @@ class LogStash::Filters::DNS < LogStash::Filters::Base
         raw = raw.first
       end
 
+      if !raw.kind_of?(String)
+        @logger.warn("DNS: skipping resolve, can't deal with non-string values", :field => field, :value => raw)
+        return
+      end
+
       begin
         return if @failed_cache && @failed_cache[raw] # recently failed resolv, skip
         if @hit_cache
@@ -268,6 +273,11 @@ class LogStash::Filters::DNS < LogStash::Filters::Base
             return
           end
           raw = raw.first
+      end
+      
+      if !raw.kind_of?(String)
+        @logger.warn("DNS: skipping reverse, can't deal with non-string values", :field => field, :value => raw)
+        return
       end
 
       if ! @ip_validator.match(raw)

--- a/logstash-filter-dns.gemspec
+++ b/logstash-filter-dns.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-dns'
-  s.version         = '3.1.4'
+  s.version         = '3.1.5'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Performs a standard or reverse DNS lookup"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/dns_spec.rb
+++ b/spec/filters/dns_spec.rb
@@ -82,13 +82,13 @@ describe LogStash::Filters::DNS do
         allow(plugin.logger).to receive(:warn).with(any_args)
       end
 
-      it "should not throw an error when filtering" do
+      it "does not throw an error when filtering" do
         expect do
           plugin.filter(event)
         end.not_to raise_error
       end
 
-      it "should log a warning" do
+      it "logs an informative warning" do
         plugin.filter(event)
         expect(plugin.logger).to have_received(:warn).with("DNS: skipping reverse, can't deal with non-string values", :field => "foo", value: {"ip" => "1.2.3.4"})
       end

--- a/spec/filters/dns_spec.rb
+++ b/spec/filters/dns_spec.rb
@@ -72,6 +72,27 @@ describe LogStash::Filters::DNS do
         insist { subject.get("foo")[1] } == "carrera.databits.net"
       end
     end
+    
+    describe "dns reverse lookup, non-string field" do
+      let(:plugin) { ::LogStash::Filters::DNS.new("reverse" => "foo") }
+      let(:event) { ::LogStash::Event.new("foo" => {"ip" => "1.2.3.4"} ) }
+
+      before do
+        plugin.register
+        allow(plugin.logger).to receive(:warn).with(any_args)
+      end
+
+      it "should not throw an error when filtering" do
+        expect do
+          plugin.filter(event)
+        end.not_to raise_error
+      end
+
+      it "should log a warning" do
+        plugin.filter(event)
+        expect(plugin.logger).to have_received(:warn).with("DNS: skipping reverse, can't deal with non-string values", :field => "foo", value: {"ip" => "1.2.3.4"})
+      end
+    end
 
     describe "dns reverse lookup, not an IP" do
       config <<-CONFIG
@@ -208,6 +229,21 @@ describe LogStash::Filters::DNS do
 
       sample("foo" => ["carrera.databits.net", "foo.databits.net"]) do
         insist { subject.get("foo") } == ["carrera.databits.net", "foo.databits.net"]
+      end
+    end
+
+    describe "dns resolve lookup, skip non-string value" do
+      config <<-CONFIG
+        filter {
+          dns {
+            resolve => "foo"
+            action => "replace"
+          }
+        }
+      CONFIG
+
+      sample("foo" => { "hostname" => "carrera.databits.net" }) do
+        insist { subject.get("foo") } == { "hostname" => "carrera.databits.net" }
       end
     end
 


### PR DESCRIPTION
When this plugin encounters a non-string (or non-single-element-array-of-strings) value in either `resolve` or `reverse`, log a warning instead of crashing.

Related: https://github.com/elastic/logstash/issues/13975