### PR TITLE
Add tag(s) DNS lookup time out.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 Gemfile.lock
 .bundle
 vendor
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 3.2.0
   - Support adding tag(s) on DNS lookup times out, defaults to `["_dnstimeout"]` [#67](https://github.com/logstash-plugins/logstash-filter-dns/pull/67)
-  - Added `warn_on_timeout` configuration to decide producing warning on DNS lookup timeouts, defaults to `true` which generates warn log. [#67](https://github.com/logstash-plugins/logstash-filter-dns/pull/67)
+  - As timeouts can be received through tags now, DNS lookup timeouts are logged in debug logs only. [#67](https://github.com/logstash-plugins/logstash-filter-dns/pull/67)
 
 ## 3.1.5
   - Fixed an issue where a non-string value existing in the resolve/reverse field could cause the plugin to crash [#65](https://github.com/logstash-plugins/logstash-filter-dns/pull/65)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.1.6
+## 3.2.0
   - Support adding tag(s) on DNS lookup times out, defaults to `["_dnstimeout"]` [#67](https://github.com/logstash-plugins/logstash-filter-dns/pull/67)
 
 ## 3.1.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 3.2.0
   - Support adding tag(s) on DNS lookup times out, defaults to `["_dnstimeout"]` [#67](https://github.com/logstash-plugins/logstash-filter-dns/pull/67)
+  - Added `warn_on_timeout` configuration to decide producing warning on DNS lookup timeouts, defaults to `false` which generates info log. [#67](https://github.com/logstash-plugins/logstash-filter-dns/pull/67)
 
 ## 3.1.5
   - Fixed an issue where a non-string value existing in the resolve/reverse field could cause the plugin to crash [#65](https://github.com/logstash-plugins/logstash-filter-dns/pull/65)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.6
+  - Support adding tag(s) on DNS lookup times out, defaults to `["_dnstimeout"]` [#67](https://github.com/logstash-plugins/logstash-filter-dns/pull/67)
+
 ## 3.1.5
   - Fixed an issue where a non-string value existing in the resolve/reverse field could cause the plugin to crash [#65](https://github.com/logstash-plugins/logstash-filter-dns/pull/65)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 3.2.0
   - Support adding tag(s) on DNS lookup times out, defaults to `["_dnstimeout"]` [#67](https://github.com/logstash-plugins/logstash-filter-dns/pull/67)
-  - Added `warn_on_timeout` configuration to decide producing warning on DNS lookup timeouts, defaults to `false` which generates info log. [#67](https://github.com/logstash-plugins/logstash-filter-dns/pull/67)
+  - Added `warn_on_timeout` configuration to decide producing warning on DNS lookup timeouts, defaults to `true` which generates warn log. [#67](https://github.com/logstash-plugins/logstash-filter-dns/pull/67)
 
 ## 3.1.5
   - Fixed an issue where a non-string value existing in the resolve/reverse field could cause the plugin to crash [#65](https://github.com/logstash-plugins/logstash-filter-dns/pull/65)

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -187,7 +187,7 @@ Add tag(s) on DNS lookup time out.
 ===== `warn_on_timeout`
 
 * Value type is <<boolean,boolean>>
-* Defaults to `false`.
+* Defaults to `true`.
 
 A flag to determine to produce warning log on DNS lookup time out. When `false`, the plugin produces info level log.
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -59,6 +59,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-resolve>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-reverse>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-timeout>> |<<number,number>>|No
+| <<plugins-{type}s-{plugin}-tag_on_timeout>> |<<array,array>>|No
 |=======================================================================
 
 Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
@@ -173,6 +174,13 @@ Reverse resolve one or more fields.
 
 `resolv` calls will be wrapped in a timeout instance
 
+[id="plugins-{type}s-{plugin}-tag_on_timeout"]
+===== `tag_on_timeout`
+
+* Value type is <<array,array>>
+* Defaults to `["_dnstimeout"]`.
+
+Add tag(s) on DNS lookup time out.
 
 
 [id="plugins-{type}s-{plugin}-common-options"]

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -59,7 +59,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-resolve>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-reverse>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-timeout>> |<<number,number>>|No
-| <<plugins-{type}s-{plugin}-tag_on_timeout>> |<<array,array>>|No
+| <<plugins-{type}s-{plugin}-tags_on_timeout>> |<<array,array>>|No
 |=======================================================================
 
 Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
@@ -174,8 +174,8 @@ Reverse resolve one or more fields.
 
 `resolv` calls will be wrapped in a timeout instance
 
-[id="plugins-{type}s-{plugin}-tag_on_timeout"]
-===== `tag_on_timeout`
+[id="plugins-{type}s-{plugin}-tags_on_timeout"]
+===== `tags_on_timeout`
 
 * Value type is <<array,array>>
 * Defaults to `["_dnstimeout"]`.

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -59,7 +59,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-resolve>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-reverse>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-timeout>> |<<number,number>>|No
-| <<plugins-{type}s-{plugin}-tags_on_timeout>> |<<array,array>>|No
+| <<plugins-{type}s-{plugin}-tag_on_timeout>> |<<array,array>>|No
 |=======================================================================
 
 Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
@@ -174,8 +174,8 @@ Reverse resolve one or more fields.
 
 `resolv` calls will be wrapped in a timeout instance
 
-[id="plugins-{type}s-{plugin}-tags_on_timeout"]
-===== `tags_on_timeout`
+[id="plugins-{type}s-{plugin}-tag_on_timeout"]
+===== `tag_on_timeout`
 
 * Value type is <<array,array>>
 * Defaults to `["_dnstimeout"]`.

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -58,8 +58,8 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-nameserver>> |<<hash,hash>>|No
 | <<plugins-{type}s-{plugin}-resolve>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-reverse>> |<<array,array>>|No
-| <<plugins-{type}s-{plugin}-timeout>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-tag_on_timeout>> |<<array,array>>|No
+| <<plugins-{type}s-{plugin}-timeout>> |<<number,number>>|No
 |=======================================================================
 
 Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options supported by all

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -60,7 +60,6 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-reverse>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-tag_on_timeout>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-timeout>> |<<number,number>>|No
-| <<plugins-{type}s-{plugin}-warn_on_timeout>> |<<boolean,boolean>>|No
 |=======================================================================
 
 Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
@@ -182,14 +181,6 @@ Reverse resolve one or more fields.
 * Defaults to `["_dnstimeout"]`.
 
 Add tag(s) on DNS lookup time out.
-
-[id="plugins-{type}s-{plugin}-warn_on_timeout"]
-===== `warn_on_timeout`
-
-* Value type is <<boolean,boolean>>
-* Defaults to `true`.
-
-A flag to determine to produce warning log on DNS lookup time out. When `false`, the plugin produces info level log.
 
 
 [id="plugins-{type}s-{plugin}-common-options"]

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -60,6 +60,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-reverse>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-tag_on_timeout>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-timeout>> |<<number,number>>|No
+| <<plugins-{type}s-{plugin}-warn_on_timeout>> |<<boolean,boolean>>|No
 |=======================================================================
 
 Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
@@ -181,6 +182,14 @@ Reverse resolve one or more fields.
 * Defaults to `["_dnstimeout"]`.
 
 Add tag(s) on DNS lookup time out.
+
+[id="plugins-{type}s-{plugin}-warn_on_timeout"]
+===== `warn_on_timeout`
+
+* Value type is <<boolean,boolean>>
+* Defaults to `false`.
+
+A flag to determine to produce warning log on DNS lookup time out. When `false`, the plugin produces info level log.
 
 
 [id="plugins-{type}s-{plugin}-common-options"]

--- a/lib/logstash/filters/dns.rb
+++ b/lib/logstash/filters/dns.rb
@@ -91,7 +91,7 @@ class LogStash::Filters::DNS < LogStash::Filters::Base
 
   # For some cases warning timeout may bring noise but for some cases it may be sensitive
   # A config to produce warn message when timeout happens
-  config :warn_on_timeout, :validate => :boolean, :default => false
+  config :warn_on_timeout, :validate => :boolean, :default => true
 
   attr_reader :hit_cache
   attr_reader :failed_cache

--- a/lib/logstash/filters/dns.rb
+++ b/lib/logstash/filters/dns.rb
@@ -89,10 +89,6 @@ class LogStash::Filters::DNS < LogStash::Filters::Base
   # Tag(s) to apply if a DNS lookup times out. Defaults to `["_dnstimeout"]`.
   config :tag_on_timeout, :validate => :string, :list => true, :default => ["_dnstimeout"]
 
-  # For some cases warning timeout may bring noise but for some cases it may be sensitive
-  # A config to produce warn message when timeout happens
-  config :warn_on_timeout, :validate => :boolean, :default => true
-
   attr_reader :hit_cache
   attr_reader :failed_cache
 
@@ -226,12 +222,8 @@ class LogStash::Filters::DNS < LogStash::Filters::Base
         end
       rescue Resolv::ResolvTimeout
         @failed_cache[raw] = true if @failed_cache
-        log_message = "DNS: timeout on resolving the hostname."
-        if @warn_on_timeout
-          @logger.warn(log_message, :field => field, :value => raw)
-        else
-          @logger.info(log_message, :field => field, :value => raw)
-        end
+        @logger.debug("DNS: timeout on resolving the hostname.",
+                      :field => field, :value => raw)
         @tag_on_timeout.each { |tag| event.tag(tag) }
         return
       rescue SocketError => e
@@ -317,12 +309,8 @@ class LogStash::Filters::DNS < LogStash::Filters::Base
         end
       rescue Resolv::ResolvTimeout
         @failed_cache[raw] = true if @failed_cache
-        log_message = "DNS: timeout on resolving address."
-        if @warn_on_timeout
-          @logger.warn(log_message, :field => field, :value => raw)
-        else
-          @logger.info(log_message, :field => field, :value => raw)
-        end
+        @logger.debug("DNS: timeout on resolving address.",
+                      :field => field, :value => raw)
         @tag_on_timeout.each { |tag| event.tag(tag) }
         return
       rescue SocketError => e

--- a/lib/logstash/filters/dns.rb
+++ b/lib/logstash/filters/dns.rb
@@ -89,6 +89,10 @@ class LogStash::Filters::DNS < LogStash::Filters::Base
   # Tag(s) to apply if a DNS lookup times out. Defaults to `["_dnstimeout"]`.
   config :tag_on_timeout, :validate => :string, :list => true, :default => ["_dnstimeout"]
 
+  # For some cases warning timeout may bring noise but for some cases it may be sensitive
+  # A config to produce warn message when timeout happens
+  config :warn_on_timeout, :validate => :boolean, :default => false
+
   attr_reader :hit_cache
   attr_reader :failed_cache
 
@@ -222,8 +226,12 @@ class LogStash::Filters::DNS < LogStash::Filters::Base
         end
       rescue Resolv::ResolvTimeout
         @failed_cache[raw] = true if @failed_cache
-        @logger.info("DNS: timeout on resolving the hostname.",
-                      :field => field, :value => raw)
+        log_message = "DNS: timeout on resolving the hostname."
+        if @warn_on_timeout
+          @logger.warn(log_message, :field => field, :value => raw)
+        else
+          @logger.info(log_message, :field => field, :value => raw)
+        end
         @tag_on_timeout.each { |tag| event.tag(tag) }
         return
       rescue SocketError => e
@@ -309,8 +317,12 @@ class LogStash::Filters::DNS < LogStash::Filters::Base
         end
       rescue Resolv::ResolvTimeout
         @failed_cache[raw] = true if @failed_cache
-        @logger.info("DNS: timeout on resolving address.",
-                      :field => field, :value => raw)
+        log_message = "DNS: timeout on resolving address."
+        if @warn_on_timeout
+          @logger.warn(log_message, :field => field, :value => raw)
+        else
+          @logger.info(log_message, :field => field, :value => raw)
+        end
         @tag_on_timeout.each { |tag| event.tag(tag) }
         return
       rescue SocketError => e

--- a/lib/logstash/filters/dns.rb
+++ b/lib/logstash/filters/dns.rb
@@ -87,7 +87,7 @@ class LogStash::Filters::DNS < LogStash::Filters::Base
   config :hostsfile, :validate => :array
 
   # Tag(s) to apply if a DNS lookup times out. Defaults to `["_dnstimeout"]`.
-  config :tags_on_timeout, :validate => :array, :default => ["_dnstimeout"]
+  config :tag_on_timeout, :validate => :array, :default => ["_dnstimeout"]
 
   attr_reader :hit_cache
   attr_reader :failed_cache
@@ -224,7 +224,7 @@ class LogStash::Filters::DNS < LogStash::Filters::Base
         @failed_cache[raw] = true if @failed_cache
         @logger.info("DNS: timeout on resolving the hostname.",
                       :field => field, :value => raw)
-        @tags_on_timeout.each { |tag| event.tag(tag) }
+        @tag_on_timeout.each { |tag| event.tag(tag) }
         return
       rescue SocketError => e
         @logger.error("DNS: Encountered SocketError.",
@@ -311,7 +311,7 @@ class LogStash::Filters::DNS < LogStash::Filters::Base
         @failed_cache[raw] = true if @failed_cache
         @logger.info("DNS: timeout on resolving address.",
                       :field => field, :value => raw)
-        @tags_on_timeout.each { |tag| event.tag(tag) }
+        @tag_on_timeout.each { |tag| event.tag(tag) }
         return
       rescue SocketError => e
         @logger.error("DNS: Encountered SocketError.",

--- a/lib/logstash/filters/dns.rb
+++ b/lib/logstash/filters/dns.rb
@@ -87,7 +87,7 @@ class LogStash::Filters::DNS < LogStash::Filters::Base
   config :hostsfile, :validate => :array
 
   # Tag(s) to apply if a DNS lookup times out. Defaults to `["_dnstimeout"]`.
-  config :tag_on_timeout, :validate => :array, :default => ["_dnstimeout"]
+  config :tags_on_timeout, :validate => :array, :default => ["_dnstimeout"]
 
   attr_reader :hit_cache
   attr_reader :failed_cache
@@ -224,7 +224,7 @@ class LogStash::Filters::DNS < LogStash::Filters::Base
         @failed_cache[raw] = true if @failed_cache
         @logger.info("DNS: timeout on resolving the hostname.",
                       :field => field, :value => raw)
-        @tag_on_timeout.each {|tag| event.tag(tag)}
+        @tags_on_timeout.each { |tag| event.tag(tag) }
         return
       rescue SocketError => e
         @logger.error("DNS: Encountered SocketError.",
@@ -311,7 +311,7 @@ class LogStash::Filters::DNS < LogStash::Filters::Base
         @failed_cache[raw] = true if @failed_cache
         @logger.info("DNS: timeout on resolving address.",
                       :field => field, :value => raw)
-        @tag_on_timeout.each {|tag| event.tag(tag)}
+        @tags_on_timeout.each { |tag| event.tag(tag) }
         return
       rescue SocketError => e
         @logger.error("DNS: Encountered SocketError.",
@@ -350,7 +350,7 @@ class LogStash::Filters::DNS < LogStash::Filters::Base
     tries = 0
     begin
       block.call
-    rescue Resolv::ResolvTimeout,  SocketError
+    rescue Resolv::ResolvTimeout, SocketError
       if tries < @max_retries
         tries = tries + 1
         retry

--- a/lib/logstash/filters/dns.rb
+++ b/lib/logstash/filters/dns.rb
@@ -87,7 +87,7 @@ class LogStash::Filters::DNS < LogStash::Filters::Base
   config :hostsfile, :validate => :array
 
   # Tag(s) to apply if a DNS lookup times out. Defaults to `["_dnstimeout"]`.
-  config :tag_on_timeout, :validate => :array, :default => ["_dnstimeout"]
+  config :tag_on_timeout, :validate => :string, :list => true, :default => ["_dnstimeout"]
 
   attr_reader :hit_cache
   attr_reader :failed_cache

--- a/logstash-filter-dns.gemspec
+++ b/logstash-filter-dns.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-dns'
-  s.version         = '3.1.6'
+  s.version         = '3.2.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Performs a standard or reverse DNS lookup"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-filter-dns.gemspec
+++ b/logstash-filter-dns.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-dns'
-  s.version         = '3.1.5'
+  s.version         = '3.1.6'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Performs a standard or reverse DNS lookup"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/dns_spec.rb
+++ b/spec/filters/dns_spec.rb
@@ -746,7 +746,7 @@ describe LogStash::Filters::DNS do
       end
 
       context "with warn on timeout disabled" do
-        let(:config) { { "reverse" => ["message"], "warn_on_timeout" => true } }
+        let(:config) { { "reverse" => ["message"], "warn_on_timeout" => false } }
         let(:event) { LogStash::Event.new("message" => "127.0.0.1") }
 
         before do

--- a/spec/filters/dns_spec.rb
+++ b/spec/filters/dns_spec.rb
@@ -659,6 +659,37 @@ describe LogStash::Filters::DNS do
         expect(event.get("tags")).to eq(nil)
       end
     end
+
+    context "when logging" do
+
+      context "with default on timeout disabled" do
+        let(:config) { { "resolve" => ["message"] } }
+        let(:event) { LogStash::Event.new("message" => "127.0.0.1") }
+
+        before do
+          allow(subject.logger).to receive(:info).with(any_args)
+        end
+
+        it "should log timeout in info level log" do
+          subject.filter(event)
+          expect(subject.logger).to have_received(:info).with("DNS: timeout on resolving the hostname.", :field => "message", :value => "127.0.0.1")
+        end
+      end
+
+      context "with warn on timeout enabled" do
+        let(:config) { { "resolve" => ["message"], "warn_on_timeout" => true } }
+        let(:event) { LogStash::Event.new("message" => "127.0.0.1") }
+
+        before do
+          allow(subject.logger).to receive(:warn).with(any_args)
+        end
+
+        it "should log timeout in warn level log" do
+          subject.filter(event)
+          expect(subject.logger).to have_received(:warn).with("DNS: timeout on resolving the hostname.", :field => "message", :value => "127.0.0.1")
+        end
+      end
+    end
   end
 
   describe "dns reverse timeout" do
@@ -695,6 +726,37 @@ describe LogStash::Filters::DNS do
 
       it "should not add any failure tags" do
         expect(event.get("tags")).to eq(nil)
+      end
+    end
+
+    context "when logging" do
+
+      context "with default on timeout disabled" do
+        let(:config) { { "reverse" => ["message"] } }
+        let(:event) { LogStash::Event.new("message" => "127.0.0.1") }
+
+        before do
+          allow(subject.logger).to receive(:info).with(any_args)
+        end
+
+        it "should log timeout in info level log" do
+          subject.filter(event)
+          expect(subject.logger).to have_received(:info).with("DNS: timeout on resolving address.", :field => "message", :value => "127.0.0.1")
+        end
+      end
+
+      context "with warn on timeout enabled" do
+        let(:config) { { "reverse" => ["message"], "warn_on_timeout" => true } }
+        let(:event) { LogStash::Event.new("message" => "127.0.0.1") }
+
+        before do
+          allow(subject.logger).to receive(:warn).with(any_args)
+        end
+
+        it "should log timeout in warn level log" do
+          subject.filter(event)
+          expect(subject.logger).to have_received(:warn).with("DNS: timeout on resolving address.", :field => "message", :value => "127.0.0.1")
+        end
       end
     end
   end

--- a/spec/filters/dns_spec.rb
+++ b/spec/filters/dns_spec.rb
@@ -7,6 +7,7 @@ require "logstash/filters/dns/resolv_patch"
 
 
 describe LogStash::Filters::DNS do
+
   describe "with stubbed Resolv" do
     before(:each) do
       # We use `Resolv#each_address` and `Resolv#each_name`, which have
@@ -627,7 +628,7 @@ describe LogStash::Filters::DNS do
     let(:subject) { LogStash::Filters::DNS.new(config) }
 
     before(:each) do
-      allow(subject).to receive(:getaddress).and_raise Timeout::Error
+      allow(subject).to receive(:getaddress).and_raise(Resolv::ResolvTimeout)
       subject.register
       subject.filter(event)
     end
@@ -642,7 +643,7 @@ describe LogStash::Filters::DNS do
     end
 
     context "when using a custom tag" do
-      let(:config) { { "resolve" => ["message"], "tag_on_timeout" => ["dns_custom_timeout"] } }
+      let(:config) { { "resolve" => ["message"], "tags_on_timeout" => ["dns_custom_timeout"] } }
       let(:event) { LogStash::Event.new("message" => "carrera.databits.net") }
 
       it "should add the custom DNS timeout tag" do
@@ -651,7 +652,7 @@ describe LogStash::Filters::DNS do
     end
 
     context "when using no tags" do
-      let(:config) { { "resolve" => ["message"], "tag_on_timeout" => [] } }
+      let(:config) { { "resolve" => ["message"], "tags_on_timeout" => [] } }
       let(:event) { LogStash::Event.new("message" => "carrera.databits.net") }
 
       it "should not add any failure tags" do
@@ -665,7 +666,7 @@ describe LogStash::Filters::DNS do
     let(:subject) { LogStash::Filters::DNS.new(config) }
 
     before(:each) do
-      allow(subject).to receive(:getname).and_raise Timeout::Error
+      allow(subject).to receive(:getname).and_raise(Resolv::ResolvTimeout)
       subject.register
       subject.filter(event)
     end
@@ -680,7 +681,7 @@ describe LogStash::Filters::DNS do
     end
 
     context "when using a custom tag" do
-      let(:config) { { "reverse" => ["message"], "tag_on_timeout" => ["dns_custom_timeout"] } }
+      let(:config) { { "reverse" => ["message"], "tags_on_timeout" => ["dns_custom_timeout"] } }
       let(:event) { LogStash::Event.new("message" => "127.0.0.1") }
 
       it "should add the custom DNS timeout tag" do
@@ -689,7 +690,7 @@ describe LogStash::Filters::DNS do
     end
 
     context "when using no tags" do
-      let(:config) { { "reverse" => ["message"], "tag_on_timeout" => [] } }
+      let(:config) { { "reverse" => ["message"], "tags_on_timeout" => [] } }
       let(:event) { LogStash::Event.new("message" => "127.0.0.1") }
 
       it "should not add any failure tags" do

--- a/spec/filters/dns_spec.rb
+++ b/spec/filters/dns_spec.rb
@@ -621,4 +621,81 @@ describe LogStash::Filters::DNS do
       end
     end
   end
+
+  describe "dns forward timeout" do
+
+    let(:subject) { LogStash::Filters::DNS.new(config) }
+
+    before(:each) do
+      allow(subject).to receive(:getaddress).and_raise Timeout::Error
+      subject.register
+      subject.filter(event)
+    end
+
+    context "when using the default tag" do
+      let(:config) { { "resolve" => ["message"] } }
+      let(:event) { LogStash::Event.new("message" => "carrera.databits.net") }
+
+      it "should add the default DNS timeout tag" do
+        expect(event.get("tags")).to eq(["_dnstimeout"])
+      end
+    end
+
+    context "when using a custom tag" do
+      let(:config) { { "resolve" => ["message"], "tag_on_timeout" => ["dns_custom_timeout"] } }
+      let(:event) { LogStash::Event.new("message" => "carrera.databits.net") }
+
+      it "should add the custom DNS timeout tag" do
+        expect(event.get("tags")).to eq(["dns_custom_timeout"])
+      end
+    end
+
+    context "when using no tags" do
+      let(:config) { { "resolve" => ["message"], "tag_on_timeout" => [] } }
+      let(:event) { LogStash::Event.new("message" => "carrera.databits.net") }
+
+      it "should not add any failure tags" do
+        expect(event.get("tags")).to eq(nil)
+      end
+    end
+  end
+
+  describe "dns reverse timeout" do
+
+    let(:subject) { LogStash::Filters::DNS.new(config) }
+
+    before(:each) do
+      allow(subject).to receive(:getname).and_raise Timeout::Error
+      subject.register
+      subject.filter(event)
+    end
+
+    context "when using the default tag" do
+      let(:config) { { "reverse" => ["message"] } }
+      let(:event) { LogStash::Event.new("message" => "127.0.0.1") }
+
+      it "should add the default DNS timeout tag" do
+        expect(event.get("tags")).to eq(["_dnstimeout"])
+      end
+    end
+
+    context "when using a custom tag" do
+      let(:config) { { "reverse" => ["message"], "tag_on_timeout" => ["dns_custom_timeout"] } }
+      let(:event) { LogStash::Event.new("message" => "127.0.0.1") }
+
+      it "should add the custom DNS timeout tag" do
+        expect(event.get("tags")).to eq(["dns_custom_timeout"])
+      end
+    end
+
+    context "when using no tags" do
+      let(:config) { { "reverse" => ["message"], "tag_on_timeout" => [] } }
+      let(:event) { LogStash::Event.new("message" => "127.0.0.1") }
+
+      it "should not add any failure tags" do
+        expect(event.get("tags")).to eq(nil)
+      end
+    end
+  end
+
 end

--- a/spec/filters/dns_spec.rb
+++ b/spec/filters/dns_spec.rb
@@ -662,31 +662,17 @@ describe LogStash::Filters::DNS do
 
     context "when logging" do
 
-      context "with default on timeout enabled" do
+      context "with debug" do
         let(:config) { { "resolve" => ["message"] } }
         let(:event) { LogStash::Event.new("message" => "127.0.0.1") }
 
         before do
-          allow(subject.logger).to receive(:warn).with(any_args)
+          allow(subject.logger).to receive(:debug).with(any_args)
         end
 
-        it "should log timeout in warn level log" do
+        it "logs on timeout exception" do
           subject.filter(event)
-          expect(subject.logger).to have_received(:warn).with("DNS: timeout on resolving the hostname.", :field => "message", :value => "127.0.0.1")
-        end
-      end
-
-      context "with warn on timeout disabled" do
-        let(:config) { { "resolve" => ["message"], "warn_on_timeout" => false } }
-        let(:event) { LogStash::Event.new("message" => "127.0.0.1") }
-
-        before do
-          allow(subject.logger).to receive(:info).with(any_args)
-        end
-
-        it "should log timeout in info level log" do
-          subject.filter(event)
-          expect(subject.logger).to have_received(:info).with("DNS: timeout on resolving the hostname.", :field => "message", :value => "127.0.0.1")
+          expect(subject.logger).to have_received(:debug).with("DNS: timeout on resolving the hostname.", :field => "message", :value => "127.0.0.1")
         end
       end
     end
@@ -731,31 +717,17 @@ describe LogStash::Filters::DNS do
 
     context "when logging" do
 
-      context "with default on timeout enabled" do
+      context "with debug" do
         let(:config) { { "reverse" => ["message"] } }
         let(:event) { LogStash::Event.new("message" => "127.0.0.1") }
 
         before do
-          allow(subject.logger).to receive(:warn).with(any_args)
+          allow(subject.logger).to receive(:debug).with(any_args)
         end
 
-        it "should log timeout in warn level log" do
+        it "logs timeout exception" do
           subject.filter(event)
-          expect(subject.logger).to have_received(:warn).with("DNS: timeout on resolving address.", :field => "message", :value => "127.0.0.1")
-        end
-      end
-
-      context "with warn on timeout disabled" do
-        let(:config) { { "reverse" => ["message"], "warn_on_timeout" => false } }
-        let(:event) { LogStash::Event.new("message" => "127.0.0.1") }
-
-        before do
-          allow(subject.logger).to receive(:info).with(any_args)
-        end
-
-        it "should log timeout in info level log" do
-          subject.filter(event)
-          expect(subject.logger).to have_received(:info).with("DNS: timeout on resolving address.", :field => "message", :value => "127.0.0.1")
+          expect(subject.logger).to have_received(:debug).with("DNS: timeout on resolving address.", :field => "message", :value => "127.0.0.1")
         end
       end
     end

--- a/spec/filters/dns_spec.rb
+++ b/spec/filters/dns_spec.rb
@@ -662,22 +662,8 @@ describe LogStash::Filters::DNS do
 
     context "when logging" do
 
-      context "with default on timeout disabled" do
+      context "with default on timeout enabled" do
         let(:config) { { "resolve" => ["message"] } }
-        let(:event) { LogStash::Event.new("message" => "127.0.0.1") }
-
-        before do
-          allow(subject.logger).to receive(:info).with(any_args)
-        end
-
-        it "should log timeout in info level log" do
-          subject.filter(event)
-          expect(subject.logger).to have_received(:info).with("DNS: timeout on resolving the hostname.", :field => "message", :value => "127.0.0.1")
-        end
-      end
-
-      context "with warn on timeout enabled" do
-        let(:config) { { "resolve" => ["message"], "warn_on_timeout" => true } }
         let(:event) { LogStash::Event.new("message" => "127.0.0.1") }
 
         before do
@@ -687,6 +673,20 @@ describe LogStash::Filters::DNS do
         it "should log timeout in warn level log" do
           subject.filter(event)
           expect(subject.logger).to have_received(:warn).with("DNS: timeout on resolving the hostname.", :field => "message", :value => "127.0.0.1")
+        end
+      end
+
+      context "with warn on timeout disabled" do
+        let(:config) { { "resolve" => ["message"], "warn_on_timeout" => false } }
+        let(:event) { LogStash::Event.new("message" => "127.0.0.1") }
+
+        before do
+          allow(subject.logger).to receive(:info).with(any_args)
+        end
+
+        it "should log timeout in info level log" do
+          subject.filter(event)
+          expect(subject.logger).to have_received(:info).with("DNS: timeout on resolving the hostname.", :field => "message", :value => "127.0.0.1")
         end
       end
     end
@@ -731,22 +731,8 @@ describe LogStash::Filters::DNS do
 
     context "when logging" do
 
-      context "with default on timeout disabled" do
+      context "with default on timeout enabled" do
         let(:config) { { "reverse" => ["message"] } }
-        let(:event) { LogStash::Event.new("message" => "127.0.0.1") }
-
-        before do
-          allow(subject.logger).to receive(:info).with(any_args)
-        end
-
-        it "should log timeout in info level log" do
-          subject.filter(event)
-          expect(subject.logger).to have_received(:info).with("DNS: timeout on resolving address.", :field => "message", :value => "127.0.0.1")
-        end
-      end
-
-      context "with warn on timeout enabled" do
-        let(:config) { { "reverse" => ["message"], "warn_on_timeout" => true } }
         let(:event) { LogStash::Event.new("message" => "127.0.0.1") }
 
         before do
@@ -756,6 +742,20 @@ describe LogStash::Filters::DNS do
         it "should log timeout in warn level log" do
           subject.filter(event)
           expect(subject.logger).to have_received(:warn).with("DNS: timeout on resolving address.", :field => "message", :value => "127.0.0.1")
+        end
+      end
+
+      context "with warn on timeout disabled" do
+        let(:config) { { "reverse" => ["message"], "warn_on_timeout" => true } }
+        let(:event) { LogStash::Event.new("message" => "127.0.0.1") }
+
+        before do
+          allow(subject.logger).to receive(:info).with(any_args)
+        end
+
+        it "should log timeout in info level log" do
+          subject.filter(event)
+          expect(subject.logger).to have_received(:info).with("DNS: timeout on resolving address.", :field => "message", :value => "127.0.0.1")
         end
       end
     end

--- a/spec/filters/dns_spec.rb
+++ b/spec/filters/dns_spec.rb
@@ -643,7 +643,7 @@ describe LogStash::Filters::DNS do
     end
 
     context "when using a custom tag" do
-      let(:config) { { "resolve" => ["message"], "tags_on_timeout" => ["dns_custom_timeout"] } }
+      let(:config) { { "resolve" => ["message"], "tag_on_timeout" => ["dns_custom_timeout"] } }
       let(:event) { LogStash::Event.new("message" => "carrera.databits.net") }
 
       it "should add the custom DNS timeout tag" do
@@ -652,7 +652,7 @@ describe LogStash::Filters::DNS do
     end
 
     context "when using no tags" do
-      let(:config) { { "resolve" => ["message"], "tags_on_timeout" => [] } }
+      let(:config) { { "resolve" => ["message"], "tag_on_timeout" => [] } }
       let(:event) { LogStash::Event.new("message" => "carrera.databits.net") }
 
       it "should not add any failure tags" do
@@ -681,7 +681,7 @@ describe LogStash::Filters::DNS do
     end
 
     context "when using a custom tag" do
-      let(:config) { { "reverse" => ["message"], "tags_on_timeout" => ["dns_custom_timeout"] } }
+      let(:config) { { "reverse" => ["message"], "tag_on_timeout" => ["dns_custom_timeout"] } }
       let(:event) { LogStash::Event.new("message" => "127.0.0.1") }
 
       it "should add the custom DNS timeout tag" do
@@ -690,7 +690,7 @@ describe LogStash::Filters::DNS do
     end
 
     context "when using no tags" do
-      let(:config) { { "reverse" => ["message"], "tags_on_timeout" => [] } }
+      let(:config) { { "reverse" => ["message"], "tag_on_timeout" => [] } }
       let(:event) { LogStash::Event.new("message" => "127.0.0.1") }
 
       it "should not add any failure tags" do


### PR DESCRIPTION
### Description
We had feature requests (#24, #47) to support the tag on DNS look up timeouts and it seems we had a contribution ([PR](https://github.com/logstash-plugins/logstash-filter-dns/pull/53)) but author didn't follow up to end.

This change covers followings:
- adds a tag on timeout, defaults to `_dnstimeout`
- adds `warn_on_timeout` config to tune the log level when dns time out occurs

This PR intends to cover remain works of [original PR](https://github.com/logstash-plugins/logstash-filter-dns/pull/53).

### Closes
Closes #24
Closes #47 