### PR TITLE
[DOC] Alphabetize option descriptions

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -166,14 +166,6 @@ Forward resolve one or more fields.
 
 Reverse resolve one or more fields.
 
-[id="plugins-{type}s-{plugin}-timeout"]
-===== `timeout` 
-
-  * Value type is <<number,number>>
-  * Default value is `0.5`
-
-`resolv` calls will be wrapped in a timeout instance
-
 [id="plugins-{type}s-{plugin}-tag_on_timeout"]
 ===== `tag_on_timeout`
 
@@ -182,6 +174,13 @@ Reverse resolve one or more fields.
 
 Add tag(s) on DNS lookup time out.
 
-
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]
+
+[id="plugins-{type}s-{plugin}-timeout"]
+===== `timeout` 
+
+  * Value type is <<number,number>>
+  * Default value is `0.5`
+
+`resolv` calls will be wrapped in a timeout instance

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -180,5 +180,6 @@ Add tag(s) on DNS lookup time out.
   * Default value is `0.5`
 
 `resolv` calls will be wrapped in a timeout instance
+
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -168,19 +168,17 @@ Reverse resolve one or more fields.
 
 [id="plugins-{type}s-{plugin}-tag_on_timeout"]
 ===== `tag_on_timeout`
-
 * Value type is <<array,array>>
 * Defaults to `["_dnstimeout"]`.
 
 Add tag(s) on DNS lookup time out.
 
-[id="plugins-{type}s-{plugin}-common-options"]
-include::{include_path}/{type}.asciidoc[]
+[id="{version}-plugins-{type}s-{plugin}-timeout"]
+===== `timeout`
 
-[id="plugins-{type}s-{plugin}-timeout"]
-===== `timeout` 
-
-  * Value type is <<number,number>>
+  * Value type is {logstash-ref}/configuration-file-structure.html#number[number]
   * Default value is `0.5`
 
 `resolv` calls will be wrapped in a timeout instance
+[id="plugins-{type}s-{plugin}-common-options"]
+include::{include_path}/{type}.asciidoc[]

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -173,7 +173,7 @@ Reverse resolve one or more fields.
 
 Add tag(s) on DNS lookup time out.
 
-[id="{version}-plugins-{type}s-{plugin}-timeout"]
+[id="plugins-{type}s-{plugin}-timeout"]
 ===== `timeout`
 
   * Value type is {logstash-ref}/configuration-file-structure.html#number[number]


### PR DESCRIPTION
Options should be listed in alpha order in both the table listing and descriptions
