### PR TITLE
Fix dictionary definition passed into the spec methods

### DIFF
--- a/spec/filters/dns_spec.rb
+++ b/spec/filters/dns_spec.rb
@@ -32,7 +32,7 @@ describe LogStash::Filters::DNS do
         }
       CONFIG
 
-      sample("foo" => "199.192.228.250") do
+      sample({"foo" => "199.192.228.250"}) do
         insist { subject.get("foo") } == "carrera.databits.net"
       end
     end
@@ -68,7 +68,7 @@ describe LogStash::Filters::DNS do
         }
       CONFIG
 
-      sample("foo" => "199.192.228.250") do
+      sample({"foo" => "199.192.228.250"}) do
         insist { subject.get("foo")[0] } == "199.192.228.250"
         insist { subject.get("foo")[1] } == "carrera.databits.net"
       end
@@ -104,7 +104,7 @@ describe LogStash::Filters::DNS do
         }
       CONFIG
 
-      sample("foo" => "not.an.ip") do
+      sample({"foo" => "not.an.ip"}) do
         insist { subject.get("foo") } == "not.an.ip"
       end
     end
@@ -120,7 +120,7 @@ describe LogStash::Filters::DNS do
         }
       CONFIG
 
-      sample("host" => "carrera.databits.net") do
+      sample({"host" => "carrera.databits.net"}) do
         insist { subject.get("host") } == "199.192.228.250"
         insist { subject.get("tags") } == ["success"]
       end
@@ -158,7 +158,7 @@ describe LogStash::Filters::DNS do
         }
       CONFIG
 
-      sample("host1" => "carrera.databits.net", "host2" => "nonexistanthostname###.net") do
+      sample({"host1" => "carrera.databits.net", "host2" => "nonexistanthostname###.net"}) do
         insist { subject.get("tags") }.nil?
         insist { subject.get("host1") } == "199.192.228.250"
         insist { subject.get("host2") } == "nonexistanthostname###.net"
@@ -176,7 +176,7 @@ describe LogStash::Filters::DNS do
         }
       CONFIG
 
-      sample("host1" => "carrera.databits.net", "host2" => "carrera.databits.net") do
+      sample({"host1" => "carrera.databits.net", "host2" => "carrera.databits.net"}) do
         insist { subject.get("tags") } == ["success"]
       end
     end
@@ -193,9 +193,9 @@ describe LogStash::Filters::DNS do
         }
       CONFIG
 
-      sample("host1" => "carrera.databits.net",
+      sample({"host1" => "carrera.databits.net",
              "ip1" => "127.0.0.1",
-             "ip2" => "128.0.0.1") do
+             "ip2" => "128.0.0.1"}) do
         insist { subject.get("tags") }.nil?
         insist { subject.get("host1") } == "199.192.228.250"
         insist { subject.get("ip1") } == "localhost"
@@ -213,7 +213,7 @@ describe LogStash::Filters::DNS do
         }
       CONFIG
 
-      sample("foo" => "carrera.databits.net") do
+      sample({"foo" => "carrera.databits.net"}) do
         insist { subject.get("foo") } == "199.192.228.250"
       end
     end
@@ -228,7 +228,7 @@ describe LogStash::Filters::DNS do
         }
       CONFIG
 
-      sample("foo" => ["carrera.databits.net", "foo.databits.net"]) do
+      sample({"foo" => ["carrera.databits.net", "foo.databits.net"]}) do
         insist { subject.get("foo") } == ["carrera.databits.net", "foo.databits.net"]
       end
     end
@@ -243,7 +243,7 @@ describe LogStash::Filters::DNS do
         }
       CONFIG
 
-      sample("foo" => { "hostname" => "carrera.databits.net" }) do
+      sample({"foo" => { "hostname" => "carrera.databits.net" }}) do
         insist { subject.get("foo") } == { "hostname" => "carrera.databits.net" }
       end
     end
@@ -258,7 +258,7 @@ describe LogStash::Filters::DNS do
         }
       CONFIG
 
-      sample("foo" => "carrera.databits.net") do
+      sample({"foo" => "carrera.databits.net"}) do
         insist { subject.get("foo")[0] } == "carrera.databits.net"
         insist { subject.get("foo")[1] } == "199.192.228.250"
       end
@@ -274,7 +274,7 @@ describe LogStash::Filters::DNS do
         }
       CONFIG
 
-      sample("foo" => ["carrera.databits.net", "foo.databits.net"]) do
+      sample({"foo" => ["carrera.databits.net", "foo.databits.net"]}) do
         insist { subject.get("foo") } == ["carrera.databits.net", "foo.databits.net"]
       end
     end
@@ -288,7 +288,7 @@ describe LogStash::Filters::DNS do
         }
       CONFIG
 
-      sample("foo" => "does.not.exist") do
+      sample({"foo" => "does.not.exist"}) do
         insist { subject.get("foo") } == "does.not.exist"
       end
     end
@@ -304,7 +304,7 @@ describe LogStash::Filters::DNS do
         }
       CONFIG
 
-      sample("host" => "carrera.databits.net") do
+      sample({"host" => "carrera.databits.net"}) do
         insist { subject.get("host") } == "199.192.228.250"
       end
     end
@@ -320,7 +320,7 @@ describe LogStash::Filters::DNS do
         }
       CONFIG
 
-      sample("host" => "carrera.databits.net") do
+      sample({"host" => "carrera.databits.net"}) do
         insist { subject.get("host") } == "199.192.228.250"
       end
     end
@@ -336,7 +336,7 @@ describe LogStash::Filters::DNS do
         }
       CONFIG
 
-      sample("host" => "carrera.databits.net") do
+      sample({"host" => "carrera.databits.net"}) do
         insist { subject.get("host") } == "199.192.228.250"
       end
     end


### PR DESCRIPTION
Fix dictionary definition passed into the spec methods, to be compliant with JRuby 9.4

## How to test
same steps as https://github.com/logstash-plugins/logstash-filter-cidr/pull/26