### PR TITLE
Uninstall lru_redux and install sin_lru_redux

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -51,8 +51,10 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-action>> |<<string,string>>, one of `["append", "replace"]`|No
 | <<plugins-{type}s-{plugin}-failed_cache_size>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-failed_cache_ttl>> |<<number,number>>|No
+| <<plugins-{type}s-{plugin}-ignore_empty_failed_cache>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-hit_cache_size>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-hit_cache_ttl>> |<<number,number>>|No
+| <<plugins-{type}s-{plugin}-ignore_empty_hit_cache>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-hostsfile>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-max_retries>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-nameserver>> |<<hash,hash>>|No
@@ -68,7 +70,7 @@ filter plugins.
 &nbsp;
 
 [id="plugins-{type}s-{plugin}-action"]
-===== `action` 
+===== `action`
 
   * Value can be any of: `append`, `replace`
   * Default value is `"append"`
@@ -77,7 +79,7 @@ Determine what action to do: append or replace the values in the fields
 specified under `reverse` and `resolve`.
 
 [id="plugins-{type}s-{plugin}-failed_cache_size"]
-===== `failed_cache_size` 
+===== `failed_cache_size`
 
   * Value type is <<number,number>>
   * Default value is `0` (cache disabled)
@@ -85,15 +87,21 @@ specified under `reverse` and `resolve`.
 cache size for failed requests
 
 [id="plugins-{type}s-{plugin}-failed_cache_ttl"]
-===== `failed_cache_ttl` 
+===== `failed_cache_ttl`
 
   * Value type is <<number,number>>
   * Default value is `5`
 
 how long to cache failed requests (in seconds)
 
+[id="plugins-{type}s-{plugin}-ignore_empty_failed_cache"]
+===== `ignore_empty_failed_cache`
+
+  * Value type is <<boolean,boolean>>
+  * Default value is `true`
+
 [id="plugins-{type}s-{plugin}-hit_cache_size"]
-===== `hit_cache_size` 
+===== `hit_cache_size`
 
   * Value type is <<number,number>>
   * Default value is `0` (cache disabled)
@@ -101,15 +109,21 @@ how long to cache failed requests (in seconds)
 set the size of cache for successful requests
 
 [id="plugins-{type}s-{plugin}-hit_cache_ttl"]
-===== `hit_cache_ttl` 
+===== `hit_cache_ttl`
 
   * Value type is <<number,number>>
   * Default value is `60`
 
+[id="plugins-{type}s-{plugin}-ignore_empty_hit_cache"]
+===== `ignore_empty_hit_cache`
+
+  * Value type is <<boolean,boolean>>
+  * Default value is `true`
+
 how long to cache successful requests (in seconds)
 
 [id="plugins-{type}s-{plugin}-hostsfile"]
-===== `hostsfile` 
+===== `hostsfile`
 
   * Value type is <<array,array>>
   * There is no default value for this setting.
@@ -117,7 +131,7 @@ how long to cache successful requests (in seconds)
 Use custom hosts file(s). For example: `["/var/db/my_custom_hosts"]`
 
 [id="plugins-{type}s-{plugin}-max_retries"]
-===== `max_retries` 
+===== `max_retries`
 
   * Value type is <<number,number>>
   * Default value is `2`
@@ -125,7 +139,7 @@ Use custom hosts file(s). For example: `["/var/db/my_custom_hosts"]`
 number of times to retry a failed resolve/reverse
 
 [id="plugins-{type}s-{plugin}-nameserver"]
-===== `nameserver` 
+===== `nameserver`
 
   * Value type is <<hash,hash>>, and is composed of:
   ** a required `address` key, whose value is either a <<string,string>> or an <<array,array>>, representing one or more nameserver ip addresses
@@ -151,7 +165,7 @@ configure the resolver using the `nameserver`, `domain`,
 `search` and `ndots` directives in `/etc/resolv.conf`.
 
 [id="plugins-{type}s-{plugin}-resolve"]
-===== `resolve` 
+===== `resolve`
 
   * Value type is <<array,array>>
   * There is no default value for this setting.
@@ -159,7 +173,7 @@ configure the resolver using the `nameserver`, `domain`,
 Forward resolve one or more fields.
 
 [id="plugins-{type}s-{plugin}-reverse"]
-===== `reverse` 
+===== `reverse`
 
   * Value type is <<array,array>>
   * There is no default value for this setting.

--- a/lib/logstash/filters/dns.rb
+++ b/lib/logstash/filters/dns.rb
@@ -77,11 +77,17 @@ class LogStash::Filters::DNS < LogStash::Filters::Base
   # how long to cache successful requests (in seconds)
   config :hit_cache_ttl, :validate => :number, :default => 60
 
+  # Enable or disable caching nil values
+  config :ignore_empty_hit_cache, :validate => :boolean, :default => true
+
   # cache size for failed requests
   config :failed_cache_size, :validate => :number, :default => 0
 
   # how long to cache failed requests (in seconds)
   config :failed_cache_ttl, :validate => :number, :default => 5
+
+  # Enable or disable caching nil values
+  config :ignore_empty_failed_cache, :validate => :boolean, :default => true
 
   # Use custom hosts file(s). For example: `["/var/db/my_custom_hosts"]`
   config :hostsfile, :validate => :array
@@ -101,11 +107,11 @@ class LogStash::Filters::DNS < LogStash::Filters::Base
     end
 
     if @hit_cache_size > 0
-      @hit_cache = LruRedux::TTL::ThreadSafeCache.new(@hit_cache_size, @hit_cache_ttl)
+      @hit_cache = LruRedux::TTL::ThreadSafeCache.new(@hit_cache_size, @hit_cache_ttl, @ignore_empty_hit_cache)
     end
 
     if @failed_cache_size > 0
-      @failed_cache = LruRedux::TTL::ThreadSafeCache.new(@failed_cache_size, @failed_cache_ttl)
+      @failed_cache = LruRedux::TTL::ThreadSafeCache.new(@failed_cache_size, @failed_cache_ttl, @ignore_empty_failed_cache)
     end
 
     @ip_validator = Resolv::AddressRegex
@@ -278,7 +284,7 @@ class LogStash::Filters::DNS < LogStash::Filters::Base
           end
           raw = raw.first
       end
-      
+
       if !raw.kind_of?(String)
         @logger.warn("DNS: skipping reverse, can't deal with non-string values", :field => field, :value => raw)
         return

--- a/logstash-filter-dns.gemspec
+++ b/logstash-filter-dns.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
-  s.add_runtime_dependency 'lru_redux', "~> 1.1.0"
+  s.add_runtime_dependency 'sin_lru_redux', "~> 2.5"
 
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'insist'


### PR DESCRIPTION
## What's changed

- Uninstall lru_redux and install sin_lru_redux because lru_redux has not been maintained for over 10 years
- Add ignore_empty_cache option for saving memory
